### PR TITLE
Enable OE bit when setting pin output, and clear it when setting input

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -252,6 +252,12 @@ $(
                 .[<reg_ $gpio_i _drv>]().bits(0) // disabled
                 .[<reg_ $gpio_i _smt>]().clear_bit()
             });
+            // If we're an input clear the Output Enable bit as well, else set it.
+            if ie {
+                glb.gpio_cfgctl34.modify(|_, w| w.[<reg_ $gpio_i _oe>]().clear_bit());
+            } else {
+                glb.gpio_cfgctl34.modify(|_, w| w.[<reg_ $gpio_i _oe>]().set_bit());
+            }
         }
             $Pini { _mode: PhantomData }
         }


### PR DESCRIPTION
You need to set the output enable bit of gpio_cfgctl34 in order for a GPIO to function as output.
This is specified in the reference manual, with no register information.
Digging through the C SDK I found the Output Enable function and it only sets/clears this bit, so this should be sufficient