### PR TITLE
Uart fixes and delay code brought over from gd32vf103-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2018"
 bl602-pac = { path = "../bl602-pac" }
 embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal" }
 embedded-time = { git = "https://github.com/FluenTech/embedded-time" }
+riscv = "0.6.0"
 nb = "*"
 paste = "1"

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,7 +1,7 @@
 //! Delays
 
-use embedded_hal::blocking::delay::{DelayUs, DelayMs};
 use core::convert::Infallible;
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
 ///
@@ -9,7 +9,7 @@ use core::convert::Infallible;
 /// bit-banging protocols, etc
 #[derive(Copy, Clone)]
 pub struct McycleDelay {
-    core_frequency: u32
+    core_frequency: u32,
 }
 
 impl McycleDelay {
@@ -18,7 +18,7 @@ impl McycleDelay {
         Self {
             /// System clock frequency, used to convert clock cycles
             /// into real-world time values
-            core_frequency: freq
+            core_frequency: freq,
         }
     }
 
@@ -38,7 +38,7 @@ impl McycleDelay {
     #[inline]
     pub fn delay_cycles(cycle_count: u64) {
         let start_cycle_count = McycleDelay::get_cycle_count();
-        while McycleDelay::cycles_since(start_cycle_count) <= cycle_count { }
+        while McycleDelay::cycles_since(start_cycle_count) <= cycle_count {}
     }
 }
 
@@ -47,9 +47,7 @@ impl DelayUs<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
     fn try_delay_us(&mut self, us: u64) -> Result<(), Infallible> {
-        McycleDelay::delay_cycles(
-            (us * (self.core_frequency as u64)) / 1_000_000
-        );
+        McycleDelay::delay_cycles((us * (self.core_frequency as u64)) / 1_000_000);
         Ok(())
     }
 }
@@ -59,9 +57,7 @@ impl DelayMs<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]
     fn try_delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
-        McycleDelay::delay_cycles(
-            (ms * (self.core_frequency as u64)) / 1000
-        );
+        McycleDelay::delay_cycles((ms * (self.core_frequency as u64)) / 1000);
         Ok(())
     }
 }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,41 @@
+//! Delays
+
+use embedded_hal::timer::CountDown;
+use crate::clock::Clocks;
+use embedded_hal::blocking::delay::{DelayUs, DelayMs};
+/// Machine mode cycle counter (`mcycle`) as a delay provider
+#[derive(Copy, Clone)]
+pub struct McycleDelay {
+    core_frequency: u32
+}
+#[derive(Debug, Clone)]
+pub struct DelayError;
+
+impl McycleDelay {
+    /// Constructs the delay provider based on provided core clock frequency
+    pub fn new(freq: u32) -> Self {
+        Self {
+            core_frequency: freq
+        }
+    }
+}
+
+impl DelayUs<u64> for McycleDelay {
+    type Error = DelayError;
+    fn try_delay_us(&mut self, us: u64) -> Result<(), <Self as DelayUs<u64>>::Error>  {
+        let t0 = riscv::register::mcycle::read64();
+        let clocks = (us * (self.core_frequency as u64)) / 1_000_000;
+        while riscv::register::mcycle::read64().wrapping_sub(t0) <= clocks { }
+        Ok(())
+    }
+}
+
+impl DelayMs<u64> for McycleDelay {
+    type Error = DelayError;
+    fn try_delay_ms(&mut self, us: u64) -> Result<(), <Self as DelayMs<u64>>::Error>  {
+        let t0 = riscv::register::mcycle::read64();
+        let clocks = (us * (self.core_frequency as u64)) / 1000;
+        while riscv::register::mcycle::read64().wrapping_sub(t0) <= clocks { }
+        Ok(())
+    }
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -32,8 +32,8 @@ impl McycleDelay {
 
     /// return the number of elapsed cycles since provided cycle_count
     #[inline]
-    pub fn cycles_since(cycle_count: u64) -> u64 {
-        riscv::register::mcycle::read64().wrapping_sub(cycle_count)
+    pub fn cycles_since(previous_cycle_count: u64) -> u64 {
+        riscv::register::mcycle::read64().wrapping_sub(previous_cycle_count)
     }
 
     /// perform a busy-wait loop until the number of cycles requested has elapsed

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -5,15 +5,14 @@ use crate::clock::Clocks;
 use embedded_hal::blocking::delay::{DelayUs, DelayMs};
 use core::convert::Infallible;
 
-/// Machine mode cycle counter (`mcycle`) as a delay provider
+/// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
+/// This can be used for high resolution delays for device initialization,
+/// bit-banging with interrupts disabled, etc
 #[derive(Copy, Clone)]
 pub struct McycleDelay {
     core_frequency: u32
 }
 
-/// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
-/// This can be used for high resolution delays for device initialization,
-/// bit-banging with interrupts disabled, etc
 impl McycleDelay {
     /// Constructs the delay provider based on provided core clock frequency
     pub fn new(freq: u32) -> Self {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -19,12 +19,16 @@ impl McycleDelay {
         }
     }
 
-    pub fn get_time() -> u64 {
+    /// retrieve the cycle count for the current HART
+    #[inline]
+    pub fn get_cycle_count() -> u64 {
         riscv::register::mcycle::read64()
     }
 
-    pub fn elapsed_us(time: u64) -> u64 {
-        riscv::register::mcycle::read64().wrapping_sub(time)
+    /// return the number of elapsed cycles since provided cycle_count
+    #[inline]
+    pub fn cycles_since(cycle_count: u64) -> u64 {
+        riscv::register::mcycle::read64().wrapping_sub(cycle_count)
     }
 }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,13 +1,12 @@
 //! Delays
 
-use embedded_hal::timer::CountDown;
-use crate::clock::Clocks;
 use embedded_hal::blocking::delay::{DelayUs, DelayMs};
 use core::convert::Infallible;
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
+///
 /// This can be used for high resolution delays for device initialization,
-/// bit-banging with interrupts disabled, etc
+/// bit-banging protocols, etc
 #[derive(Copy, Clone)]
 pub struct McycleDelay {
     core_frequency: u32

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -13,7 +13,7 @@ pub struct McycleDelay {
 }
 
 impl McycleDelay {
-    /// Constructs the delay provider based on provided core clock frequency
+    /// Constructs the delay provider based on core clock frequency `freq`
     pub fn new(freq: u32) -> Self {
         Self {
             /// System clock frequency, used to convert clock cycles
@@ -22,19 +22,19 @@ impl McycleDelay {
         }
     }
 
-    /// retrieve the cycle count for the current HART
+    /// Retrieves the cycle count for the current HART
     #[inline]
     pub fn get_cycle_count() -> u64 {
         riscv::register::mcycle::read64()
     }
 
-    /// return the number of elapsed cycles since provided cycle_count
+    /// Returns the number of elapsed cycles since `previous_cycle_count`
     #[inline]
     pub fn cycles_since(previous_cycle_count: u64) -> u64 {
         riscv::register::mcycle::read64().wrapping_sub(previous_cycle_count)
     }
 
-    /// perform a busy-wait loop until the number of cycles requested has elapsed
+    /// Performs a busy-wait loop until the number of cycles `cycle_count` has elapsed
     #[inline]
     pub fn delay_cycles(cycle_count: u64) {
         let start_cycle_count = McycleDelay::get_cycle_count();
@@ -44,7 +44,7 @@ impl McycleDelay {
 
 impl DelayUs<u64> for McycleDelay {
     type Error = Infallible;
-    // perform a busy-wait loop until the number of microseconds requested has elapsed
+    /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
     fn try_delay_us(&mut self, us: u64) -> Result<(), Infallible> {
         McycleDelay::delay_cycles(
@@ -56,7 +56,7 @@ impl DelayUs<u64> for McycleDelay {
 
 impl DelayMs<u64> for McycleDelay {
     type Error = Infallible;
-    // perform a busy-wait loop until the number of milliseconds requested has elapsed
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]
     fn try_delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
         McycleDelay::delay_cycles(

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -30,6 +30,13 @@ impl McycleDelay {
     pub fn cycles_since(cycle_count: u64) -> u64 {
         riscv::register::mcycle::read64().wrapping_sub(cycle_count)
     }
+
+    /// perform a busy-wait loop until the number of cycles requested has elapsed
+    #[inline]
+    pub fn delay_cycles(cycle_count: u64) {
+        let start_cycle_count = McycleDelay::get_cycle_count();
+        while McycleDelay::cycles_since(start_cycle_count) <= cycle_count { }
+    }
 }
 
 impl DelayUs<u64> for McycleDelay {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -18,6 +18,14 @@ impl McycleDelay {
             core_frequency: freq
         }
     }
+
+    pub fn get_time() -> u64 {
+        riscv::register::mcycle::read64()
+    }
+
+    pub fn elapsed_us(time: u64) -> u64 {
+        riscv::register::mcycle::read64().wrapping_sub(time)
+    }
 }
 
 impl DelayUs<u64> for McycleDelay {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -3,13 +3,13 @@
 use embedded_hal::timer::CountDown;
 use crate::clock::Clocks;
 use embedded_hal::blocking::delay::{DelayUs, DelayMs};
+use core::convert::Infallible;
+
 /// Machine mode cycle counter (`mcycle`) as a delay provider
 #[derive(Copy, Clone)]
 pub struct McycleDelay {
     core_frequency: u32
 }
-#[derive(Debug, Clone)]
-pub struct DelayError;
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
 /// This can be used for high resolution delays for device initialization,
@@ -45,10 +45,10 @@ impl McycleDelay {
 }
 
 impl DelayUs<u64> for McycleDelay {
-    type Error = DelayError;
+    type Error = Infallible;
     // perform a busy-wait loop until the number of microseconds requested has elapsed
     #[inline]
-    fn try_delay_us(&mut self, us: u64) -> Result<(), <Self as DelayUs<u64>>::Error>  {
+    fn try_delay_us(&mut self, us: u64) -> Result<(), Infallible> {
         McycleDelay::delay_cycles(
             (us * (self.core_frequency as u64)) / 1_000_000
         );
@@ -57,10 +57,10 @@ impl DelayUs<u64> for McycleDelay {
 }
 
 impl DelayMs<u64> for McycleDelay {
-    type Error = DelayError;
+    type Error = Infallible;
     // perform a busy-wait loop until the number of milliseconds requested has elapsed
     #[inline]
-    fn try_delay_ms(&mut self, ms: u64) -> Result<(), <Self as DelayMs<u64>>::Error>  {
+    fn try_delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
         McycleDelay::delay_cycles(
             (ms * (self.core_frequency as u64)) / 1000
         );

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -41,7 +41,7 @@ pub mod uart_sig {
 
 
 macro_rules! impl_uart_sig {
-    ($UartSigi: ident, $doc1: expr, $UartMuxi: ident, $doc2: expr) => {
+    ($UartSigi: ident, $doc1: expr, $sigi:ident, $UartMuxi: ident, $doc2: expr) => {
 
     #[doc = $doc1]
     pub struct $UartSigi;
@@ -86,23 +86,25 @@ macro_rules! impl_uart_sig {
         }
         #[inline]
         fn into_uart_mode<T>(self, mode: u8) -> $UartMuxi<T> {
+            paste::paste! {
             let glb = unsafe { &*pac::GLB::ptr() };
-            glb.uart_sig_sel_0.write(|w| unsafe { w
-                .uart_sig_5_sel().bits(mode)
+            glb.uart_sig_sel_0.modify(|_r, w| unsafe { w
+                .[<uart_ $sigi _sel>]().bits(mode)
             });
+            }
             $UartMuxi { _mode: PhantomData }
         }
     }
     };
 }    
-    impl_uart_sig!(UartSig0, "Uart signal 0 (type state)", UartMux0, "Uart multiplexer peripherals for signal 0");
-    impl_uart_sig!(UartSig1, "Uart signal 1 (type state)", UartMux1, "Uart multiplexer peripherals for signal 1");
-    impl_uart_sig!(UartSig2, "Uart signal 2 (type state)", UartMux2, "Uart multiplexer peripherals for signal 2");
-    impl_uart_sig!(UartSig3, "Uart signal 3 (type state)", UartMux3, "Uart multiplexer peripherals for signal 3");
-    impl_uart_sig!(UartSig4, "Uart signal 4 (type state)", UartMux4, "Uart multiplexer peripherals for signal 4");
-    impl_uart_sig!(UartSig5, "Uart signal 5 (type state)", UartMux5, "Uart multiplexer peripherals for signal 5");
-    impl_uart_sig!(UartSig6, "Uart signal 6 (type state)", UartMux6, "Uart multiplexer peripherals for signal 6");
-    impl_uart_sig!(UartSig7, "Uart signal 7 (type state)", UartMux7, "Uart multiplexer peripherals for signal 7");
+    impl_uart_sig!(UartSig0, "Uart signal 0 (type state)", sig_0, UartMux0, "Uart multiplexer peripherals for signal 0");
+    impl_uart_sig!(UartSig1, "Uart signal 1 (type state)", sig_1, UartMux1, "Uart multiplexer peripherals for signal 1");
+    impl_uart_sig!(UartSig2, "Uart signal 2 (type state)", sig_2, UartMux2, "Uart multiplexer peripherals for signal 2");
+    impl_uart_sig!(UartSig3, "Uart signal 3 (type state)", sig_3, UartMux3, "Uart multiplexer peripherals for signal 3");
+    impl_uart_sig!(UartSig4, "Uart signal 4 (type state)", sig_4, UartMux4, "Uart multiplexer peripherals for signal 4");
+    impl_uart_sig!(UartSig5, "Uart signal 5 (type state)", sig_5, UartMux5, "Uart multiplexer peripherals for signal 5");
+    impl_uart_sig!(UartSig6, "Uart signal 6 (type state)", sig_6, UartMux6, "Uart multiplexer peripherals for signal 6");
+    impl_uart_sig!(UartSig7, "Uart signal 7 (type state)", sig_7, UartMux7, "Uart multiplexer peripherals for signal 7");
 }
 
 /// Clock configurator registers

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -255,11 +255,7 @@ $(
                 .[<reg_ $gpio_i _smt>]().clear_bit()
             });
             // If we're an input clear the Output Enable bit as well, else set it.
-            if ie {
-                glb.gpio_cfgctl34.modify(|_, w| w.[<reg_ $gpio_i _oe>]().clear_bit());
-            } else {
-                glb.gpio_cfgctl34.modify(|_, w| w.[<reg_ $gpio_i _oe>]().set_bit());
-            }
+            glb.gpio_cfgctl34.modify(|_, w| w.[<reg_ $gpio_i _oe>]().bit(!ie));
         }
             $Pini { _mode: PhantomData }
         }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -244,7 +244,7 @@ $(
         #[inline] fn into_pin_with_mode<T>(&self, mode: u8, pu: bool, pd: bool, ie: bool) -> $Pini<T> {
             let glb = unsafe { &*pac::GLB::ptr() }; 
         paste::paste! {
-            glb.$gpio_cfgctli.write(|w| unsafe { w
+            glb.$gpio_cfgctli.modify(|_r, w| unsafe { w
                 .[<reg_ $gpio_i _func_sel>]().bits(mode) 
                 .[<reg_ $gpio_i _ie>]().bit(ie) // output
                 .[<reg_ $gpio_i _pu>]().bit(pu)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use bl602_pac as pac;
 pub mod clock;
 pub mod gpio;
 pub mod serial;
+pub mod delay;
 
 /// HAL crate prelude
 pub mod prelude {


### PR DESCRIPTION
Needed some delay functions to initialise peripherals correctly, so I've ported some of the functions from
https://github.com/gd32v-rust/gd32vf103-hal/blob/master/src/delay.rs
There's a few changes to them due to newer version of embedded-hal.

Fixed up bug when allocating GPIO to UART that was overwriting adjacent pins, breaking JTAG.
Added some missing UART->GPIO muxing impls so that
https://github.com/sipeed/bl602-rust-guide/blob/main/src/main.rs
will run.