### PR TITLE
Core clock initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ embedded-time = { git = "https://github.com/FluenTech/embedded-time" }
 riscv = "0.6.0"
 nb = "*"
 paste = "1"
-# num_enum = "*"

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -38,6 +38,7 @@ pub struct Strict {
 }
 
 /// HBN root clock type definition
+#[allow(dead_code)]
 #[repr(u8)]
 enum HBN_ROOT_CLK_Type {
     RC32M = 0,           // use RC32M as root clock
@@ -48,6 +49,7 @@ enum HBN_ROOT_CLK_Type {
 /**
  *  @brief PLL XTAL type definition
  */
+ #[allow(dead_code)]
  #[repr(u8)]
 enum GLB_PLL_XTAL_Type {
     NONE        = 0,     // XTAL is none

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -106,12 +106,17 @@ impl Strict {
         self
     }
 
+    /// Enables PLL clock source, using external XTAL frequency provided
     pub fn use_pll(mut self, freq: impl Into<Hertz>) -> Self
     {
         self.pll_xtal_freq = Some(freq.into().0);
         self
     }
 
+    /// Set the system clock frequency (fclk/hclk)
+    ///
+    /// Supported frequencies:
+    ///   `32_000_000`, `48_000_000`, `80_000_000`, `120_000_000`, `160_000_000`
     pub fn sys_clk(mut self, freq: impl Into<Hertz>) -> Self
     {
         self.sysclk = Some(freq.into().0);

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -190,7 +190,7 @@ fn system_core_clock_set(value:u32){
     })
 }
 
-pub fn system_core_clock_get() -> u32 {
+fn system_core_clock_get() -> u32 {
     unsafe { &*pac::HBN::ptr() }.hbn_rsv2.read().bits()
 }
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -9,6 +9,9 @@ use crate::pac::Peripherals;
 use embedded_hal::blocking::delay::{DelayUs};
 use crate::delay::*;
 pub struct Clocks {
+    target_clksrc: HbnRootClkType,
+    pll_xtal: GlbPllXtalType,
+    target_sys_ck: SysClk,
     uart_clk_div: u8,
 }
 
@@ -474,8 +477,15 @@ impl Strict {
             .uart_clk_en().set_bit()
         });
 
+        let target_clksrc = HbnRootClkType::PLL;
+        let pll_xtal = GlbPllXtalType::Xtal40m;
+        let target_sys_ck = SysClk::Pll160m;
+
         Clocks {
-            uart_clk_div
+            target_clksrc,
+            pll_xtal,
+            target_sys_ck,
+            uart_clk_div,
         }
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -375,14 +375,14 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     });
     
     /* reg_pll_en = 1, cannot be zero */
-    dp.GLB.clk_cfg0.modify(|r, w| {w
+    dp.GLB.clk_cfg0.modify(|_, w| {w
         .reg_pll_en().set_bit()
     });
 
     /* select pll output clock before select root clock */
     // sets to clkFreq-GLB_SYS_CLK_PLL48M, where PLL160M is 2 more than PLL48M
     // Doing this with a match seems more Rusty
-    dp.GLB.clk_cfg0.modify(|r, w| unsafe {w
+    dp.GLB.clk_cfg0.modify(|_, w| unsafe {w
         .reg_pll_sel().bits(
             match clk {
                 SysClk::PLL48M => 0,

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -146,17 +146,9 @@ fn pds_power_off_pll(){
 }
 
 /// Minimal implementation of power-on pll. Currently only allows external xtal
-fn pds_power_on_pll(xtal: GlbPllXtalType) {
+fn pds_power_on_pll(freq: u32) {
     let pds = unsafe { &*pac::PDS::ptr() };
     let mut delay = McycleDelay::new(system_core_clock_get());
-    let freq = match xtal{
-        Xtal24m => 24_000_000,
-        Xtal32m => 32_000_000,
-        Xtal38p4m => 38_400_000,
-        Xtal40m => 40_000_000,
-        Xtal26m => 26_000_000,
-        _ => panic!()
-    };
 
     /**************************/
     /* select PLL XTAL source */
@@ -345,17 +337,17 @@ pub fn glb_set_system_clk(xtal: GlbPllXtalType, clk: SysClk) {
         return;
     }
     // Configure XTAL, PLL and select it as clock source for fclk
-    glb_set_system_clk_pll(clk);
+    glb_set_system_clk_pll(clk, 40_000_000);
 }
 
-fn glb_set_system_clk_pll(clk: SysClk) {
+fn glb_set_system_clk_pll(clk: SysClk, xtal_freq: u32) {
     /* reg_bclk_en = reg_hclk_en = reg_fclk_en = 1, cannot be zero */
     let glb = unsafe { &*pac::GLB::ptr() };
     // Power up the external crystal before we start up the PLL
     aon_power_on_xtal();
 
     /* always power up PLL and enable all PLL clock output */
-    pds_power_on_pll(GlbPllXtalType::Xtal40m);
+    pds_power_on_pll(xtal_freq);
 
     let mut delay = McycleDelay::new(system_core_clock_get());
     delay.try_delay_us(55).unwrap();

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -300,8 +300,9 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
     });
 }
 
-fn aon_power_on_xtal(dp: &mut Peripherals) {
-    dp.AON.rf_top_aon.modify(|_, w| { w
+fn aon_power_on_xtal() {
+    let aon = unsafe { &*pac::AON::ptr() };
+    aon.rf_top_aon.modify(|_, w| { w
         .pu_xtal_aon().set_bit()
         .pu_xtal_buf_aon().set_bit()
     });
@@ -309,7 +310,7 @@ fn aon_power_on_xtal(dp: &mut Peripherals) {
     let mut delaysrc = McycleDelay::new(system_core_clock_get());
     let mut timeout:u32 = 0;
     delaysrc.try_delay_us(10).unwrap();
-    while dp.AON.tsen.read().xtal_rdy().bit_is_clear() && timeout < 120{
+    while aon.tsen.read().xtal_rdy().bit_is_clear() && timeout < 120{
         delaysrc.try_delay_us(10).unwrap();
         timeout+=1;
     }
@@ -374,7 +375,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
         GLB_PLL_XTAL_RC32M => {}
         _ => {
             /* AON_Power_On_XTAL(); */
-            aon_power_on_xtal(dp);
+            aon_power_on_xtal();
         }
     }
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -146,7 +146,7 @@ fn aon_power_on_xtal(dp: &mut Peripherals) {
 }
 
 fn hbn_set_root_clk_sel(dp: &mut Peripherals, sel: HBN_ROOT_CLK_Type){
-     dp.GLB.clk_cfg0.modify(|r,w| unsafe { w
+    dp.HBN.hbn_glb.modify(|r,w| unsafe { w
         .hbn_root_clk_sel().bits(
             match sel {
                 HBN_ROOT_CLK_RC32M=>  0b00u8,

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -300,11 +300,11 @@ fn aon_power_on_xtal(dp: &mut Peripherals) {
     });
 
     let mut delaysrc = McycleDelay::new(system_core_clock_get(dp));
-    let mut timeOut:u32 = 0;
+    let mut timeout:u32 = 0;
     delaysrc.try_delay_us(10).unwrap();
-    while dp.AON.tsen.read().xtal_rdy().bit_is_clear() && timeOut < 120{
+    while dp.AON.tsen.read().xtal_rdy().bit_is_clear() && timeout < 120{
         delaysrc.try_delay_us(10).unwrap();
-        timeOut+=1;
+        timeout+=1;
     }
     // TODO: error out on timeout
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -113,7 +113,7 @@ fn glb_set_system_clk_div(dp: &mut Peripherals, hclkdiv:u8, bclkdiv:u8){
 }
 
 
-fn pds_select_xtal_as_pll_ref(dp: &mut Peripherals){
+fn pds_select_xtal_as_pll_ref(){
     let pds = unsafe { &*pac::PDS::ptr() };
     pds.clkpll_top_ctrl.modify(|_r,w| {w
         .clkpll_refclk_sel().set_bit()
@@ -121,7 +121,7 @@ fn pds_select_xtal_as_pll_ref(dp: &mut Peripherals){
     });
 }
 
-fn pds_power_off_pll(dp: &mut Peripherals){
+fn pds_power_off_pll(){
     /* pu_clkpll_sfreg=0 */
     /* pu_clkpll=0 */
     let pds = unsafe { &*pac::PDS::ptr() };
@@ -143,7 +143,7 @@ fn pds_power_off_pll(dp: &mut Peripherals){
 }
 
 /// Minimal implementation of power-on pll. Currently only allows external xtal
-fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
+fn pds_power_on_pll(xtal: GlbPllXtalType) {
     let pds = unsafe { &*pac::PDS::ptr() };
     let mut delay = McycleDelay::new(system_core_clock_get());
     /**************************/
@@ -156,14 +156,14 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
             //pds_trim_rc32m(dp);
             //pds_select_rc32m_as_pll_ref(dp)
         },
-        _ => pds_select_xtal_as_pll_ref(dp)
+        _ => pds_select_xtal_as_pll_ref()
     }
 
     /*******************************************/
     /* PLL power down first, not indispensable */
     /*******************************************/
     /* power off PLL first, this step is not indispensable */
-    pds_power_off_pll(dp);
+    pds_power_off_pll();
 
     /********************/
     /* PLL param config */
@@ -316,7 +316,7 @@ fn aon_power_on_xtal(dp: &mut Peripherals) {
     // TODO: error out on timeout
 }
 
-fn hbn_set_root_clk_sel(dp: &mut Peripherals, sel: HbnRootClkType){
+fn hbn_set_root_clk_sel(sel: HbnRootClkType){
     let hbn = unsafe { &*pac::HBN::ptr() };
     hbn.hbn_glb.modify(|r,w| unsafe { w
         .hbn_root_clk_sel().bits(
@@ -347,7 +347,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     });
 
      /* Before config XTAL and PLL ,make sure root clk is from RC32M */
-    hbn_set_root_clk_sel(dp, HbnRootClkType::RC32M);
+    hbn_set_root_clk_sel(HbnRootClkType::RC32M);
 
     dp.GLB.clk_cfg0.modify(|_,w| unsafe { w
         .reg_hclk_div().bits(0)
@@ -379,7 +379,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     }
 
     /* always power up PLL and enable all PLL clock output */
-    pds_power_on_pll(dp, GlbPllXtalType::Xtal40m);
+    pds_power_on_pll(GlbPllXtalType::Xtal40m);
 
     let mut delay = McycleDelay::new(system_core_clock_get());
     delay.try_delay_us(55).unwrap();
@@ -425,7 +425,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
         });
     }
     if target_core_clk > 0 {
-        hbn_set_root_clk_sel(dp, HbnRootClkType::PLL);
+        hbn_set_root_clk_sel(HbnRootClkType::PLL);
         system_core_clock_set(target_core_clk);
     }
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -97,13 +97,13 @@ impl Strict {
         self
     }
 
-    pub fn use_pll<F>(mut self, freq: impl Into<Hertz>) -> Self
+    pub fn use_pll(mut self, freq: impl Into<Hertz>) -> Self
     {
         self.pll_xtal_freq = Some(freq.into().0);
         self
     }
 
-    pub fn sys_clk<F>(mut self, freq: impl Into<Hertz>) -> Self
+    pub fn sys_clk(mut self, freq: impl Into<Hertz>) -> Self
     {
         self.sysclk = Some(freq.into().0);
         self

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -100,7 +100,7 @@ fn glb_set_system_clk_div(dp: &mut Peripherals, hclkdiv:u8, bclkdiv:u8){
     let mut delay = McycleDelay::new(system_core_clock_get(dp));
     delay.try_delay_us(1).unwrap();
 
-    dp.GLB.clk_cfg0.modify(|_,w| unsafe { w
+    dp.GLB.clk_cfg0.modify(|_,w| { w
         .reg_hclk_en().set_bit()
         .reg_bclk_en().set_bit()
     });
@@ -109,7 +109,7 @@ fn glb_set_system_clk_div(dp: &mut Peripherals, hclkdiv:u8, bclkdiv:u8){
 
 
 fn pds_select_xtal_as_pll_ref(dp: &mut Peripherals){
-    dp.PDS.clkpll_top_ctrl.modify(|_r,w| unsafe {w
+    dp.PDS.clkpll_top_ctrl.modify(|_r,w| {w
         .clkpll_refclk_sel().set_bit()
         .clkpll_xtal_rc32m_sel().clear_bit()
     });
@@ -118,7 +118,7 @@ fn pds_select_xtal_as_pll_ref(dp: &mut Peripherals){
 fn pds_power_off_pll(dp: &mut Peripherals){
     /* pu_clkpll_sfreg=0 */
     /* pu_clkpll=0 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .pu_clkpll_sfreg().clear_bit()
         .pu_clkpll().clear_bit()
     });
@@ -127,7 +127,7 @@ fn pds_power_off_pll(dp: &mut Peripherals){
     /* clkpll_pu_pfd=0 */
     /* clkpll_pu_fbdv=0 */
     /* clkpll_pu_postdiv=0 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_pu_cp().clear_bit()
         .clkpll_pu_pfd().clear_bit()
         .clkpll_pu_fbdv().clear_bit()
@@ -241,7 +241,7 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
     /*************************/
 
     /* pu_clkpll_sfreg=1 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .pu_clkpll_sfreg().set_bit()
     });
 
@@ -249,7 +249,7 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
     delay.try_delay_us(5).unwrap();
 
     /* pu_clkpll=1 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .pu_clkpll().set_bit()
     });
 
@@ -257,7 +257,7 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
     /* clkpll_pu_pfd=1 */
     /* clkpll_pu_fbdv=1 */
     /* clkpll_pu_postdiv=1 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_pu_cp().set_bit()
         .clkpll_pu_pfd().set_bit()
         .clkpll_pu_fbdv().set_bit()
@@ -267,34 +267,34 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
     delay.try_delay_us(5).unwrap();
 
     /* clkpll_sdm_reset=1 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_sdm_reset().set_bit()
     });
     // BL602_Delay_US(1);
     delay.try_delay_us(1).unwrap();
 
     /* clkpll_reset_fbdv=1 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_reset_fbdv().set_bit()
     });
     // BL602_Delay_US(2);
     delay.try_delay_us(2).unwrap();
 
     /* clkpll_reset_fbdv=0 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_reset_fbdv().clear_bit()
     });
     // BL602_Delay_US(1);
     delay.try_delay_us(1).unwrap();
 
     /* clkpll_sdm_reset=0 */
-    dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
+    dp.PDS.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_sdm_reset().clear_bit()
     });
 }
 
 fn aon_power_on_xtal(dp: &mut Peripherals) {
-    dp.AON.rf_top_aon.modify(|_, w| unsafe { w
+    dp.AON.rf_top_aon.modify(|_, w| { w
         .pu_xtal_aon().set_bit()
         .pu_xtal_buf_aon().set_bit()
     });
@@ -325,7 +325,7 @@ fn hbn_set_root_clk_sel(dp: &mut Peripherals, sel: HbnRootClkType){
 /// TODO: finish clock init - some parts are hard-coded for 40Mhz XTAL + 160Mhz target clock
 pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysClk) {
     /* reg_bclk_en = reg_hclk_en = reg_fclk_en = 1, cannot be zero */
-    dp.GLB.clk_cfg0.modify(|_, w| unsafe { w
+    dp.GLB.clk_cfg0.modify(|_, w| { w
         .reg_bclk_en().set_bit()
         .reg_hclk_en().set_bit()
         .reg_fclk_en().set_bit()
@@ -343,7 +343,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     system_core_clock_set(dp, 32_000_000);
 
     /* Select PKA clock from hclk */
-    dp.GLB.swrst_cfg2.modify(|_,w| unsafe { w
+    dp.GLB.swrst_cfg2.modify(|_,w| { w
         .pka_clk_sel().clear_bit()
     });
 
@@ -375,7 +375,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     });
     
     /* reg_pll_en = 1, cannot be zero */
-    dp.GLB.clk_cfg0.modify(|r, w| unsafe {w
+    dp.GLB.clk_cfg0.modify(|r, w| {w
         .reg_pll_en().set_bit()
     });
 
@@ -408,7 +408,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     }
 
     if target_core_clk > 120_000_000 {
-        dp.L1C.l1c_config.modify(|r, w| unsafe {w
+        dp.L1C.l1c_config.modify(|r, w| {w
             .irom_2t_access().set_bit()
         });
     }
@@ -427,7 +427,7 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     /* select PKA clock from 120M since we power up PLL */
     // NOTE: This isn't documented in the datasheet!
     // GLB_Set_PKA_CLK_Sel(GLB_PKA_CLK_PLL120M);
-    dp.GLB.swrst_cfg2.write(|w| unsafe { w
+    dp.GLB.swrst_cfg2.write(|w| { w
         .pka_clk_sel().set_bit()
     });
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -172,10 +172,6 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
     /* PLL param config */
     /********************/
 
-    // /* clkpll_icp_1u */
-    // /* clkpll_icp_5u */
-    // /* clkpll_int_frac_sw */
-
     // The C code uses the same representation for both GLB_PLL_XTAL and PDS_PLL_XTAL - reusing that type
     match xtal {
         GlbPllXtalType::Xtal26m => {
@@ -194,11 +190,6 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
         }
     }
 
-    // /* clkpll_c3 */
-    // /* clkpll_cz */
-    // /* clkpll_rz */
-    // /* clkpll_r4 */
-    // /* clkpll_r4_short */
     match xtal {
         GlbPllXtalType::Xtal26m => {
             pds.clkpll_rz.modify(|_r, w| unsafe {w
@@ -217,14 +208,11 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
             });
         }
     }
-    // /* clkpll_refdiv_ratio */
-    // /* clkpll_postdiv */
     pds.clkpll_top_ctrl.modify(|_r, w| unsafe {w
         .clkpll_postdiv().bits(0x14)
         .clkpll_refdiv_ratio().bits(2)
     });
 
-    // /* clkpll_sdmin */
     pds.clkpll_sdm.modify(|_r, w| unsafe {w
         .clkpll_sdmin().bits(
             match xtal {
@@ -239,8 +227,6 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
         )
     });
 
-    // /* clkpll_sel_fb_clk */
-    // /* clkpll_sel_sample_clk can be 0/1, default is 1 */
     pds.clkpll_fbdv.modify(|_r, w| unsafe {w
         .clkpll_sel_fb_clk().bits(1)
         .clkpll_sel_sample_clk().bits(1)
@@ -249,55 +235,43 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
     /*************************/
     /* PLL power up sequence */
     /*************************/
-
-    /* pu_clkpll_sfreg=1 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .pu_clkpll_sfreg().set_bit()
     });
 
-    //DelayUs(5);
     delay.try_delay_us(5).unwrap();
 
-    /* pu_clkpll=1 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .pu_clkpll().set_bit()
     });
 
-    /* clkpll_pu_cp=1 */
-    /* clkpll_pu_pfd=1 */
-    /* clkpll_pu_fbdv=1 */
-    /* clkpll_pu_postdiv=1 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_pu_cp().set_bit()
         .clkpll_pu_pfd().set_bit()
         .clkpll_pu_fbdv().set_bit()
         .clkpll_pu_postdiv().set_bit()
     });
-    //DelayUs(5);
+
     delay.try_delay_us(5).unwrap();
 
-    /* clkpll_sdm_reset=1 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_sdm_reset().set_bit()
     });
-    // BL602_Delay_US(1);
+
     delay.try_delay_us(1).unwrap();
 
-    /* clkpll_reset_fbdv=1 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_reset_fbdv().set_bit()
     });
-    // BL602_Delay_US(2);
+
     delay.try_delay_us(2).unwrap();
 
-    /* clkpll_reset_fbdv=0 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_reset_fbdv().clear_bit()
     });
-    // BL602_Delay_US(1);
+
     delay.try_delay_us(1).unwrap();
 
-    /* clkpll_sdm_reset=0 */
     pds.pu_rst_clkpll.modify(|_r, w| {w
         .clkpll_sdm_reset().clear_bit()
     });

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -26,9 +26,8 @@
 
 use crate::pac;
 use crate::gpio::ClkCfg;
-use core::{num::NonZeroU32, unimplemented};
+use core::{num::NonZeroU32};
 use embedded_time::rate::Hertz;
-use crate::pac::Peripherals;
 use embedded_hal::blocking::delay::{DelayUs};
 use crate::delay::*;
 
@@ -394,7 +393,7 @@ fn glb_set_system_clk_rc32(){
         .reg_fclk_en().set_bit()
     });
 
-    // Before config XTAL and PLL ,make sure root clk is from RC32M
+    // Before config XTAL and PLL, make sure root clk is from RC32M
     hbn_set_root_clk_sel_rc32();
 
     unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| unsafe { w

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -6,7 +6,7 @@ use crate::gpio::ClkCfg;
 use core::{num::NonZeroU32, unimplemented};
 use embedded_time::rate::Hertz;
 use crate::pac::Peripherals;
-use embedded_hal::blocking::delay::{DelayUs, DelayMs};
+use embedded_hal::blocking::delay::{DelayUs};
 use crate::delay::*;
 pub struct Clocks {
     uart_clk_div: u8,
@@ -224,7 +224,6 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
                 GlbPllXtalType::Xtal40m =>  0x30_0000,
                 GlbPllXtalType::Xtal26m =>  0x49_D39D,
                 GlbPllXtalType::RC32M =>  0x3C_0000,
-                _ =>  0x3C_0000,
             }
         )
     });

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -381,8 +381,17 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GLB_PLL_XTAL_Type, clk: sy
 
     /* select pll output clock before select root clock */
     // sets to clkFreq-GLB_SYS_CLK_PLL48M, where PLL160M is 2 more than PLL48M
+    // Doing this with a match seems more Rusty
     dp.GLB.clk_cfg0.modify(|r, w| unsafe {w
-        .reg_pll_sel().bits(2)
+        .reg_pll_sel().bits(
+            match clk {
+                sys_clk::PLL48M => 0,
+                sys_clk::PLL120M => 1,
+                sys_clk::PLL160M => 2,
+                sys_clk::PLL192M => 3,
+                _ => {panic!()}
+            }
+        )
     });
 
     /* select root clock */

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -304,8 +304,7 @@ fn pds_enable_pll_all_clks(){
     });
 }
 
-/// Setup XTAL and PLL for system clock
-/// TODO: finish clock init - some parts are hard-coded for 40Mhz XTAL + 160Mhz target clock
+/// Set the system clock to use the internal 32Mhz RC oscillator
 fn glb_set_system_clk_rc32(){
     /* reg_bclk_en = reg_hclk_en = reg_fclk_en = 1, cannot be zero */
     let glb = unsafe { &*pac::GLB::ptr() };

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -15,6 +15,14 @@ pub struct Clocks {
 }
 
 impl Clocks {
+    pub fn new() -> Self {
+        Clocks {
+            pll_xtal_freq: 0,
+            sysclk: 32_000_000,
+            uart_clk_div: 0,
+        }
+    }
+
     pub fn use_pll<F>(mut self, freq: F) -> Self
     where
         F: Into<Hertz>,

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -52,22 +52,22 @@ enum HbnRootClkType {
  #[allow(dead_code)]
  #[repr(u8)]
 pub enum GlbPllXtalType {
-    NONE        = 0,     // XTAL is none
+    None        = 0,     // XTAL is none
     Xtal24m    = 1,     // XTAL is 24M
     Xtal32m    = 2,     // XTAL is 32M
     Xtal38p4m  = 3,     // XTAL is 38.4M
     Xtal40m    = 4,     // XTAL is 40M
     Xtal26m    = 5,     // XTAL is 26M
-    RC32M       = 6,     // XTAL is RC32M
+    Rc32m       = 6,     // XTAL is RC32M
 }
 #[allow(dead_code)]
 pub enum SysClk {
-    RC32M   = 0, // use RC32M as system clock frequency
-    XTAL    = 1, // use XTAL as system clock
-    PLL48M  = 2, // use PLL output 48M as system clock
-    PLL120M = 3, // use PLL output 120M as system clock
-    PLL160M = 4, // use PLL output 160M as system clock
-    PLL192M = 5, // use PLL output 192M as system clock
+    Rc32m   = 0, // use RC32M as system clock frequency
+    Xtal    = 1, // use XTAL as system clock
+    Pll48m  = 2, // use PLL output 48M as system clock
+    Pll120m = 3, // use PLL output 120M as system clock
+    Pll160m = 4, // use PLL output 160M as system clock
+    Pll192m = 5, // use PLL output 192M as system clock
 }
 
 pub fn system_core_clock_set(dp: &mut Peripherals, value:u32){
@@ -143,7 +143,7 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
     /**************************/
     match xtal {
         // TODO: There's a pretty big chunk of translation to do to support RC32 as the PLL source.
-        GlbPllXtalType::RC32M | GlbPllXtalType::NONE => {
+        GlbPllXtalType::Rc32m | GlbPllXtalType::None => {
             unimplemented!();
             //pds_trim_rc32m(dp);
             //pds_select_rc32m_as_pll_ref(dp)
@@ -217,13 +217,13 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GlbPllXtalType) {
     dp.PDS.clkpll_sdm.modify(|_r, w| unsafe {w
         .clkpll_sdmin().bits(
             match xtal {
-                GlbPllXtalType::NONE =>  0x3C_0000,
+                GlbPllXtalType::None =>  0x3C_0000,
                 GlbPllXtalType::Xtal24m =>  0x50_0000,
                 GlbPllXtalType::Xtal32m =>  0x3C_0000,
                 GlbPllXtalType::Xtal38p4m =>  0x32_0000,
                 GlbPllXtalType::Xtal40m =>  0x30_0000,
                 GlbPllXtalType::Xtal26m =>  0x49_D39D,
-                GlbPllXtalType::RC32M =>  0x3C_0000,
+                GlbPllXtalType::Rc32m =>  0x3C_0000,
             }
         )
     });
@@ -351,8 +351,8 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     // If we asked for PLL and RC32, do nothing
     // Else, we're using crystal so power that on
     match xtal {
-        GlbPllXtalType::NONE => match clk {
-            SysClk::RC32M => return,
+        GlbPllXtalType::None => match clk {
+            SysClk::Rc32m => return,
             _ => {}
         },
         GLB_PLL_XTAL_RC32M => {}
@@ -384,22 +384,22 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     dp.GLB.clk_cfg0.modify(|_, w| unsafe {w
         .reg_pll_sel().bits(
             match clk {
-                SysClk::PLL48M => 0,
-                SysClk::PLL120M => 1,
-                SysClk::PLL160M => 2,
-                SysClk::PLL192M => 3,
+                SysClk::Pll48m => 0,
+                SysClk::Pll120m => 1,
+                SysClk::Pll160m => 2,
+                SysClk::Pll192m => 3,
                 _ => {panic!()}
             }
         )
     });
 
     let target_core_clk = match clk{
-        SysClk::RC32M => 0,
-        SysClk::XTAL => 0,
-        SysClk::PLL48M => 48_000_000,
-        SysClk::PLL120M => 120_000_000,
-        SysClk::PLL160M => 160_000_000,
-        SysClk::PLL192M => 192_000_000,
+        SysClk::Rc32m => 0,
+        SysClk::Xtal => 0,
+        SysClk::Pll48m => 48_000_000,
+        SysClk::Pll120m => 120_000_000,
+        SysClk::Pll160m => 160_000_000,
+        SysClk::Pll192m => 192_000_000,
     };
 
     if target_core_clk > 48_000_000 {
@@ -473,6 +473,7 @@ impl Strict {
             .uart_clk_div().bits(uart_clk_div)
             .uart_clk_en().set_bit()
         });
+
         Clocks {
             uart_clk_div
         }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -184,12 +184,14 @@ impl Strict {
     }
 }
 
+/// Sets the system clock in the (undocumented) system_core_clock register
 fn system_core_clock_set(value:u32){
     unsafe { &*pac::HBN::ptr() }.hbn_rsv2.write(|w| unsafe { w
         .bits(value)
     })
 }
 
+/// Gets the system clock in the (undocumented) system_core_clock register
 fn system_core_clock_get() -> u32 {
     unsafe { &*pac::HBN::ptr() }.hbn_rsv2.read().bits()
 }
@@ -198,7 +200,7 @@ fn glb_set_system_clk_div(hclkdiv:u8, bclkdiv:u8){
     // recommended: fclk<=160MHz, bclk<=80MHz
     // fclk is determined by hclk_div (strange), which then feeds into bclk, hclk and uartclk
     // glb_reg_bclk_dis isn't in the SVD file, so it isn't generated through svd2rust 
-    // It's only used here.
+    // It's only used by this function so define it as a local variable
     let glb_reg_bclk_dis = 0x40000FFC as * mut u32;
     unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| unsafe { w
         .reg_hclk_div().bits(hclkdiv)
@@ -253,7 +255,6 @@ fn pds_power_on_pll(freq: u32) {
     pds_power_off_pll();
 
     // PLL param config
-    //TODO: document + research this a bit more to work out if we can run at other frequecies
     if freq == 26_000_000 {
         pds.clkpll_cp.modify(|_, w| unsafe {w
             .clkpll_icp_1u().bits(1)
@@ -384,7 +385,7 @@ fn pds_enable_pll_all_clks(){
     });
 }
 
-/// Set the system clock to use the internal 32Mhz RC oscillator
+/// Sets the system clock to use the internal 32Mhz RC oscillator
 fn glb_set_system_clk_rc32(){
     // reg_bclk_en = reg_hclk_en = reg_fclk_en = 1, cannot be zero
     unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| { w
@@ -410,6 +411,7 @@ fn glb_set_system_clk_rc32(){
     });
 }
 
+/// Sets the system clock to use the PLL with external crystal
 fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     // Ensure clock is running off internal RC oscillator before changing anything else
     glb_set_system_clk_rc32();

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -18,6 +18,11 @@
 //   It contains the root clock source selection (sysclk/flck)
 // The L1C (level 1 cache) section maps tightly-coupled ram/cache SRAM in front of slower buses
 //   (ROM, flash). It contains configuration for internal ROM access latency
+//
+// Currently implemented clock tree configuration options:
+//   - internal 32Mhz RC oscillator for sysclock
+//   - XTAL driving PLL, sysclock frequencies of 48/80/120/160/192Mhz
+//   - UART using PLL if sysclock is using PLL
 
 use crate::pac;
 use crate::gpio::ClkCfg;
@@ -406,12 +411,6 @@ fn glb_set_system_clk_rc32(){
     });
 }
 
-/// Original code supported a bunch of configurations for core clock
-/// There are probably uses for driving PLL using RC or using XTAL direct for root clock,
-/// but it complicates something that is already sufficiently complex.
-/// Settling for two configuration options for now:
-///   - internal 32Mhz RC oscillator for sysclock
-///   - XTAL driving PLL, sysclock frequencies of 48/80/120/160/192Mhz
 pub fn glb_set_system_clk(xtal_freq: u32, sysclk_freq: u32) {
     // Ensure clock is running off internal RC oscillator before changing anything else
     glb_set_system_clk_rc32();

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -397,10 +397,7 @@ fn glb_set_system_clk_rc32(){
     // Before config XTAL and PLL, make sure root clk is from RC32M
     hbn_set_root_clk_sel_rc32();
 
-    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| unsafe { w
-        .reg_hclk_div().bits(0)
-        .reg_bclk_div().bits(0)
-    });
+    glb_set_system_clk_div(0,0);
 
     // Update sysclock
     system_core_clock_set(RC32M);

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,6 +1,24 @@
 //! SoC clock configuration
 // 其实和gpio两个模块同属GLB外设
 // 时钟控制器
+// The clocking in this chip is split into several peripheral sections oriented around low power modes
+//
+// Here is a quick overview of the peripheral sections as relates to those modes
+//
+// The GLB (global register) portion of the chip controls most clock enable/division circuits
+//   as well as the GPIO
+// The AON (always on) section is parts of the SOC that are active in all but the deepest
+//   hibernate mode (HBN3). This section controls power to external high frequency crystal
+// The PDS (power-down state, sleep) is the smallest level of power saving.
+//   It always keeps CORE SRAM and timer power enabled.
+//   Power to CPU, Wireless PHY+MAC, and digital/analog pins is optionally turned off at different pre-set levels
+//   Peripherals that relate to clocking in this module: PLL
+// The HBN (hibernate, deep sleep) section is the largest level of power saving.
+//   It always turns off CPU, Wireless PHY+MAC, CORE SRAM and timers, and optionally sections or all of AON
+//   It contains the root clock source selection (sysclk/flck)
+// The L1C (level 1 cache) section maps tightly-coupled ram/cache SRAM in front of slower buses
+//   (ROM, flash). It contains configuration for internal ROM access latency
+
 use crate::pac;
 use crate::gpio::ClkCfg;
 use core::{num::NonZeroU32, unimplemented};

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -170,7 +170,7 @@ impl Strict {
         });
 
         // Write uart clock divider
-        unsafe { &*pac::GLB::ptr() }.clk_cfg2.write(|w| unsafe { w
+        unsafe { &*pac::GLB::ptr() }.clk_cfg2.modify(|_, w| unsafe { w
             .uart_clk_div().bits(uart_clk_div - 1 as u8)
             .uart_clk_en().set_bit()
         });

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -139,7 +139,7 @@ fn aon_power_on_xtal(dp: &mut Peripherals) {
     let mut timeOut:u32 = 0;
     delaysrc.try_delay_us(10).unwrap();
     while dp.AON.tsen.read().xtal_rdy().bit_is_clear() && timeOut < 120{
-        delaysrc.try_delay_us(10);
+        delaysrc.try_delay_us(10).unwrap();
         timeOut+=1;
     }
     // TODO: error out on timeout

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -313,9 +313,9 @@ fn hbn_set_root_clk_sel(dp: &mut Peripherals, sel: HBN_ROOT_CLK_Type){
     dp.HBN.hbn_glb.modify(|r,w| unsafe { w
         .hbn_root_clk_sel().bits(
             match sel {
-                HBN_ROOT_CLK_RC32M=>  0b00u8,
-                HBN_ROOT_CLK_XTAL => 0b01u8,
-                HBN_ROOT_CLK_PLL => r.hbn_root_clk_sel().bits() as u8 | 0b10u8
+                HBN_ROOT_CLK_Type::RC32M => 0b00u8,
+                HBN_ROOT_CLK_Type::XTAL => 0b01u8,
+                HBN_ROOT_CLK_Type::PLL => r.hbn_root_clk_sel().bits() as u8 | 0b10u8
             }
         )
     });

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -411,18 +411,6 @@ fn glb_set_system_clk_rc32(){
     });
 }
 
-pub fn glb_set_system_clk(xtal_freq: u32, sysclk_freq: u32) {
-    // Ensure clock is running off internal RC oscillator before changing anything else
-    glb_set_system_clk_rc32();
-    // if target clock is 32Mhz we don't have to do any more
-    if sysclk_freq == RC32M{
-        return
-    } else {
-        // Configure XTAL, PLL and select it as clock source for fclk
-        glb_set_system_clk_pll(sysclk_freq, xtal_freq)
-    }
-}
-
 fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     // Ensure clock is running off internal RC oscillator before changing anything else
     glb_set_system_clk_rc32();

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -149,7 +149,7 @@ impl Strict {
     }
 }
 
-pub fn system_core_clock_set(value:u32){
+fn system_core_clock_set(value:u32){
     let hbn = unsafe { &*pac::HBN::ptr() };
     hbn.hbn_rsv2.write(|w| unsafe { w
         .bits(value)

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -421,7 +421,8 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GlbPllXtalType, clk: SysCl
     }
 
     if target_core_clk > 120_000_000 {
-        dp.L1C.l1c_config.modify(|r, w| {w
+        let l1c = unsafe { &*pac::L1C::ptr() };
+        l1c.l1c_config.modify(|r, w| {w
             .irom_2t_access().set_bit()
         });
     }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -46,7 +46,7 @@ impl Clocks {
     pub fn freeze(self) -> Clocks {
         let glb = unsafe { &*pac::GLB::ptr() };
         glb.clk_cfg2.write(|w| unsafe { w
-            .uart_clk_div().bits(self.uart_clk_div)
+            .uart_clk_div().bits(self.uart_clk_div-1)
             .uart_clk_en().set_bit()
         });
         glb_set_system_clk(self.pll_xtal_freq, self.sysclk);

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -24,12 +24,12 @@
 //   - XTAL driving PLL, sysclock frequencies of 48/80/120/160/192Mhz
 //   - UART using PLL if sysclock is using PLL
 
-use crate::pac;
-use crate::gpio::ClkCfg;
-use core::{num::NonZeroU32};
-use embedded_time::rate::Hertz;
-use embedded_hal::blocking::delay::{DelayUs};
 use crate::delay::*;
+use crate::gpio::ClkCfg;
+use crate::pac;
+use core::num::NonZeroU32;
+use embedded_hal::blocking::delay::DelayUs;
+use embedded_time::rate::Hertz;
 
 /// Internal high-speed RC oscillator frequency
 pub const RC32M: u32 = 32_000_000;
@@ -67,11 +67,11 @@ impl Clocks {
         }
     }
 
-    pub fn sysclk(&self) -> Hertz{
+    pub fn sysclk(&self) -> Hertz {
         self.sysclk
     }
 
-    pub fn pll_enable (&self) -> bool {
+    pub fn pll_enable(&self) -> bool {
         self.pll_enable
     }
 
@@ -119,8 +119,7 @@ impl Strict {
     }
 
     /// Enables PLL clock source, using external XTAL frequency provided
-    pub fn use_pll(mut self, freq: impl Into<Hertz>) -> Self
-    {
+    pub fn use_pll(mut self, freq: impl Into<Hertz>) -> Self {
         self.pll_xtal_freq = Some(freq.into().0);
         self
     }
@@ -129,36 +128,38 @@ impl Strict {
     ///
     /// Supported frequencies:
     ///   `32_000_000`, `48_000_000`, `80_000_000`, `120_000_000`, `160_000_000`
-    pub fn sys_clk(mut self, freq: SysclkFreq) -> Self
-    {
+    pub fn sys_clk(mut self, freq: SysclkFreq) -> Self {
         self.sysclk = freq;
         self
     }
 
     /// Calculate and balance clock registers to configure into the given clock value.
-    /// If accurate value is not possible, this function panics. 
-    /// 
+    /// If accurate value is not possible, this function panics.
+    ///
     /// Be aware that Rust's panic is sometimes not obvious on embedded devices; if your
     /// program didn't execute as expected, or the `pc` is pointing to somewhere weird
-    /// (usually `abort: j abort`), it's likely that this function have panicked. 
+    /// (usually `abort: j abort`), it's likely that this function have panicked.
     /// Breakpoint on `rust_begin_unwind` may help debugging.
     ///
     /// # Panics
     ///
     /// If strictly accurate value of given `ck_sys` etc. is not reachable, this function
-    /// panics. 
+    /// panics.
     pub fn freeze(self, clk_cfg: &mut ClkCfg) -> Clocks {
         drop(clk_cfg); // logically use its ownership
 
         // Default to not using the PLL, and selecting the internal RC oscillator if nothing selected
         let pll_xtal_freq = self.pll_xtal_freq.unwrap_or(0);
-        let pll_enabled = pll_xtal_freq!=0;
+        let pll_enabled = pll_xtal_freq != 0;
         let sysclk = self.sysclk;
         // If sysclk isn't 32Mhz but PLL isn't enabled, panic
         assert!((pll_enabled) || (sysclk == SysclkFreq::Rc32Mhz));
 
         // UART config
-        let uart_clk =  self.target_uart_clk.map(|f| f.get()).unwrap_or(sysclk as u32);
+        let uart_clk = self
+            .target_uart_clk
+            .map(|f| f.get())
+            .unwrap_or(sysclk as u32);
         // If PLL is available we'll be using the PLL_160Mhz clock, otherwise sysclk
         let uart_clk_src = if pll_enabled {
             UART_PLL_FREQ
@@ -181,30 +182,32 @@ impl Strict {
 
         // If PLL is enabled, use that for the UART base clock
         // Otherwise, use sysclk as the UART clock
-        unsafe { &*pac::HBN::ptr() }.hbn_glb.modify(|r,w| unsafe { w
-            .hbn_uart_clk_sel().bit(pll_enabled)
-        });
+        unsafe { &*pac::HBN::ptr() }
+            .hbn_glb
+            .modify(|r, w| unsafe { w.hbn_uart_clk_sel().bit(pll_enabled) });
 
         // Write uart clock divider
-        unsafe { &*pac::GLB::ptr() }.clk_cfg2.modify(|_, w| unsafe { w
-            .uart_clk_div().bits(uart_clk_div - 1 as u8)
-            .uart_clk_en().set_bit()
+        unsafe { &*pac::GLB::ptr() }.clk_cfg2.modify(|_, w| unsafe {
+            w.uart_clk_div()
+                .bits(uart_clk_div - 1 as u8)
+                .uart_clk_en()
+                .set_bit()
         });
 
         Clocks {
             sysclk: Hertz(sysclk as u32),
             uart_clk: Hertz(uart_clk),
             xtal_freq: Some(Hertz(pll_xtal_freq)),
-            pll_enable: pll_enabled
+            pll_enable: pll_enabled,
         }
     }
 }
 
 /// Sets the system clock in the (undocumented) system_core_clock register
-fn system_core_clock_set(value:u32){
-    unsafe { &*pac::HBN::ptr() }.hbn_rsv2.write(|w| unsafe { w
-        .bits(value)
-    })
+fn system_core_clock_set(value: u32) {
+    unsafe { &*pac::HBN::ptr() }
+        .hbn_rsv2
+        .write(|w| unsafe { w.bits(value) })
 }
 
 /// Gets the system clock in the (undocumented) system_core_clock register
@@ -212,51 +215,53 @@ fn system_core_clock_get() -> u32 {
     unsafe { &*pac::HBN::ptr() }.hbn_rsv2.read().bits()
 }
 
-fn glb_set_system_clk_div(hclkdiv:u8, bclkdiv:u8){
+fn glb_set_system_clk_div(hclkdiv: u8, bclkdiv: u8) {
     // recommended: fclk<=160MHz, bclk<=80MHz
     // fclk is determined by hclk_div (strange), which then feeds into bclk, hclk and uartclk
-    // glb_reg_bclk_dis isn't in the SVD file, so it isn't generated through svd2rust 
+    // glb_reg_bclk_dis isn't in the SVD file, so it isn't generated through svd2rust
     // It's only used by this function so define it as a local variable
-    let glb_reg_bclk_dis = 0x40000FFC as * mut u32;
-    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| unsafe { w
-        .reg_hclk_div().bits(hclkdiv)
-        .reg_bclk_div().bits(bclkdiv)
-    });
+    let glb_reg_bclk_dis = 0x40000FFC as *mut u32;
+    unsafe { &*pac::GLB::ptr() }
+        .clk_cfg0
+        .modify(|_, w| unsafe { w.reg_hclk_div().bits(hclkdiv).reg_bclk_div().bits(bclkdiv) });
     unsafe { glb_reg_bclk_dis.write_volatile(1) };
     unsafe { glb_reg_bclk_dis.write_volatile(0) };
     let currclock = system_core_clock_get();
-    system_core_clock_set(currclock / (hclkdiv as u32 + 1) );
+    system_core_clock_set(currclock / (hclkdiv as u32 + 1));
 
     let mut delay = McycleDelay::new(system_core_clock_get());
     // This delay used to be 8 NOPS (1/4 us). Might need to be replaced again.
     delay.try_delay_us(1).unwrap();
 
-    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| { w
-        .reg_hclk_en().set_bit()
-        .reg_bclk_en().set_bit()
-    });
+    unsafe { &*pac::GLB::ptr() }
+        .clk_cfg0
+        .modify(|_, w| w.reg_hclk_en().set_bit().reg_bclk_en().set_bit());
     delay.try_delay_us(1).unwrap();
 }
 
-
-fn pds_select_xtal_as_pll_ref(){
-    unsafe { &*pac::PDS::ptr() }.clkpll_top_ctrl.modify(|_, w| {w
-        .clkpll_refclk_sel().set_bit()
-        .clkpll_xtal_rc32m_sel().clear_bit()
+fn pds_select_xtal_as_pll_ref() {
+    unsafe { &*pac::PDS::ptr() }.clkpll_top_ctrl.modify(|_, w| {
+        w.clkpll_refclk_sel()
+            .set_bit()
+            .clkpll_xtal_rc32m_sel()
+            .clear_bit()
     });
 }
 
-fn pds_power_off_pll(){
-    unsafe { &*pac::PDS::ptr() }.pu_rst_clkpll.modify(|_, w| {w
-        .pu_clkpll_sfreg().clear_bit()
-        .pu_clkpll().clear_bit()
-    });
+fn pds_power_off_pll() {
+    unsafe { &*pac::PDS::ptr() }
+        .pu_rst_clkpll
+        .modify(|_, w| w.pu_clkpll_sfreg().clear_bit().pu_clkpll().clear_bit());
 
-    unsafe { &*pac::PDS::ptr() }.pu_rst_clkpll.modify(|_, w| {w
-        .clkpll_pu_cp().clear_bit()
-        .clkpll_pu_pfd().clear_bit()
-        .clkpll_pu_fbdv().clear_bit()
-        .clkpll_pu_postdiv().clear_bit()
+    unsafe { &*pac::PDS::ptr() }.pu_rst_clkpll.modify(|_, w| {
+        w.clkpll_pu_cp()
+            .clear_bit()
+            .clkpll_pu_pfd()
+            .clear_bit()
+            .clkpll_pu_fbdv()
+            .clear_bit()
+            .clkpll_pu_postdiv()
+            .clear_bit()
     });
 }
 
@@ -270,20 +275,18 @@ fn pds_power_off_pll(){
 fn pds_power_on_pll_rom(freq: u32) {
     // Lookup table for ROM function addresses is at 0x21010800
     // offset for RomDriver_PDS_Power_On_PLL is 88
-    let power_on_pll_lut_entry = (0x21010800 + 88) as * mut usize;
+    let power_on_pll_lut_entry = (0x21010800 + 88) as *mut usize;
     let power_on_pll_addr = unsafe { power_on_pll_lut_entry.read_volatile() };
-    let romdriver_pds_power_on_pll = unsafe { 
-        core::mem::transmute::<*const(), extern "C" fn(usize)> (
-                power_on_pll_addr as *const ()
-            ) 
+    let romdriver_pds_power_on_pll = unsafe {
+        core::mem::transmute::<*const (), extern "C" fn(usize)>(power_on_pll_addr as *const ())
     };
     let xtal_src = match freq {
-        24_000_000 =>  1,
-        32_000_000 =>  2,
-        38_400_000 =>  3,
-        40_000_000 =>  4,
-        26_000_000 =>  5,
-        _ => panic!("Unsupported PLL clock source")
+        24_000_000 => 1,
+        32_000_000 => 2,
+        38_400_000 => 3,
+        40_000_000 => 4,
+        26_000_000 => 5,
+        _ => panic!("Unsupported PLL clock source"),
     };
     romdriver_pds_power_on_pll(xtal_src);
 }
@@ -302,111 +305,125 @@ fn pds_power_on_pll(freq: u32) {
 
     // PLL param config
     if freq == 26_000_000 {
-        pds.clkpll_cp.modify(|_, w| unsafe {w
-            .clkpll_icp_1u().bits(1)
-            .clkpll_icp_5u().bits(0)
-            .clkpll_int_frac_sw().set_bit()
+        pds.clkpll_cp.modify(|_, w| unsafe {
+            w.clkpll_icp_1u()
+                .bits(1)
+                .clkpll_icp_5u()
+                .bits(0)
+                .clkpll_int_frac_sw()
+                .set_bit()
         });
-        pds.clkpll_rz.modify(|_, w| unsafe {w
-            .clkpll_c3().bits(2)
-            .clkpll_cz().bits(2)
-            .clkpll_rz().bits(5)
-            .clkpll_r4_short().clear_bit()
+        pds.clkpll_rz.modify(|_, w| unsafe {
+            w.clkpll_c3()
+                .bits(2)
+                .clkpll_cz()
+                .bits(2)
+                .clkpll_rz()
+                .bits(5)
+                .clkpll_r4_short()
+                .clear_bit()
         });
     } else {
-        pds.clkpll_cp.modify(|_, w| unsafe {w
-            .clkpll_icp_1u().bits(0)
-            .clkpll_icp_5u().bits(2)
-            .clkpll_int_frac_sw().clear_bit()
+        pds.clkpll_cp.modify(|_, w| unsafe {
+            w.clkpll_icp_1u()
+                .bits(0)
+                .clkpll_icp_5u()
+                .bits(2)
+                .clkpll_int_frac_sw()
+                .clear_bit()
         });
-        pds.clkpll_rz.modify(|_, w| unsafe {w
-            .clkpll_c3().bits(3)
-            .clkpll_cz().bits(1)
-            .clkpll_rz().bits(1)
-            .clkpll_r4_short().set_bit()
+        pds.clkpll_rz.modify(|_, w| unsafe {
+            w.clkpll_c3()
+                .bits(3)
+                .clkpll_cz()
+                .bits(1)
+                .clkpll_rz()
+                .bits(1)
+                .clkpll_r4_short()
+                .set_bit()
         });
     }
 
-    pds.clkpll_top_ctrl.modify(|_, w| unsafe {w
-        .clkpll_postdiv().bits(0x14)
-        .clkpll_refdiv_ratio().bits(2)
+    pds.clkpll_top_ctrl
+        .modify(|_, w| unsafe { w.clkpll_postdiv().bits(0x14).clkpll_refdiv_ratio().bits(2) });
+
+    pds.clkpll_sdm.modify(|_, w| unsafe {
+        w.clkpll_sdmin().bits(match freq {
+            24_000_000 => 0x50_0000,
+            32_000_000 => 0x3C_0000,
+            38_400_000 => 0x32_0000,
+            40_000_000 => 0x30_0000,
+            26_000_000 => 0x49_D39D,
+            _ => panic!(),
+        })
     });
 
-    pds.clkpll_sdm.modify(|_, w| unsafe {w
-        .clkpll_sdmin().bits(
-            match freq {
-                24_000_000 =>  0x50_0000,
-                32_000_000 =>  0x3C_0000,
-                38_400_000 =>  0x32_0000,
-                40_000_000 =>  0x30_0000,
-                26_000_000 =>  0x49_D39D,
-                _ => panic!()
-            }
-        )
-    });
-
-    pds.clkpll_fbdv.modify(|_, w| unsafe {w
-        .clkpll_sel_fb_clk().bits(1)
-        .clkpll_sel_sample_clk().bits(1)
+    pds.clkpll_fbdv.modify(|_, w| unsafe {
+        w.clkpll_sel_fb_clk()
+            .bits(1)
+            .clkpll_sel_sample_clk()
+            .bits(1)
     });
 
     /*************************/
     /* PLL power up sequence */
     /*************************/
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .pu_clkpll_sfreg().set_bit()
+    pds.pu_rst_clkpll
+        .modify(|_, w| w.pu_clkpll_sfreg().set_bit());
+
+    delay.try_delay_us(5).unwrap();
+
+    pds.pu_rst_clkpll.modify(|_, w| w.pu_clkpll().set_bit());
+
+    pds.pu_rst_clkpll.modify(|_, w| {
+        w.clkpll_pu_cp()
+            .set_bit()
+            .clkpll_pu_pfd()
+            .set_bit()
+            .clkpll_pu_fbdv()
+            .set_bit()
+            .clkpll_pu_postdiv()
+            .set_bit()
     });
 
     delay.try_delay_us(5).unwrap();
 
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .pu_clkpll().set_bit()
-    });
-
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .clkpll_pu_cp().set_bit()
-        .clkpll_pu_pfd().set_bit()
-        .clkpll_pu_fbdv().set_bit()
-        .clkpll_pu_postdiv().set_bit()
-    });
-
-    delay.try_delay_us(5).unwrap();
-
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .clkpll_sdm_reset().set_bit()
-    });
+    pds.pu_rst_clkpll
+        .modify(|_, w| w.clkpll_sdm_reset().set_bit());
 
     delay.try_delay_us(1).unwrap();
 
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .clkpll_reset_fbdv().set_bit()
-    });
+    pds.pu_rst_clkpll
+        .modify(|_, w| w.clkpll_reset_fbdv().set_bit());
 
     delay.try_delay_us(2).unwrap();
 
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .clkpll_reset_fbdv().clear_bit()
-    });
+    pds.pu_rst_clkpll
+        .modify(|_, w| w.clkpll_reset_fbdv().clear_bit());
 
     delay.try_delay_us(1).unwrap();
 
-    pds.pu_rst_clkpll.modify(|_, w| {w
-        .clkpll_sdm_reset().clear_bit()
-    });
+    pds.pu_rst_clkpll
+        .modify(|_, w| w.clkpll_sdm_reset().clear_bit());
 }
 
 fn aon_power_on_xtal() -> Result<(), &'static str> {
-    unsafe { &*pac::AON::ptr() }.rf_top_aon.modify(|_, w| { w
-        .pu_xtal_aon().set_bit()
-        .pu_xtal_buf_aon().set_bit()
-    });
+    unsafe { &*pac::AON::ptr() }
+        .rf_top_aon
+        .modify(|_, w| w.pu_xtal_aon().set_bit().pu_xtal_buf_aon().set_bit());
 
     let mut delaysrc = McycleDelay::new(system_core_clock_get());
-    let mut timeout:u32 = 0;
+    let mut timeout: u32 = 0;
     delaysrc.try_delay_us(10).unwrap();
-    while unsafe { &*pac::AON::ptr() }.tsen.read().xtal_rdy().bit_is_clear() && timeout < 120{
+    while unsafe { &*pac::AON::ptr() }
+        .tsen
+        .read()
+        .xtal_rdy()
+        .bit_is_clear()
+        && timeout < 120
+    {
         delaysrc.try_delay_us(10).unwrap();
-        timeout+=1;
+        timeout += 1;
     }
     if timeout == 120 {
         Err("timeout occured")
@@ -415,47 +432,49 @@ fn aon_power_on_xtal() -> Result<(), &'static str> {
     }
 }
 
-fn hbn_set_root_clk_sel_pll(){
-    unsafe { &*pac::HBN::ptr() }.hbn_glb.modify(|r,w| unsafe { w
-        .hbn_root_clk_sel().bits(
-            r.hbn_root_clk_sel().bits() as u8 | 0b10u8
-        )
+fn hbn_set_root_clk_sel_pll() {
+    unsafe { &*pac::HBN::ptr() }.hbn_glb.modify(|r, w| unsafe {
+        w.hbn_root_clk_sel()
+            .bits(r.hbn_root_clk_sel().bits() as u8 | 0b10u8)
     });
 }
 
-fn hbn_set_root_clk_sel_rc32(){
-    unsafe { &*pac::HBN::ptr() }.hbn_glb.modify(|_, w| unsafe { w
-        .hbn_root_clk_sel().bits(0b00u8)
-    });
+fn hbn_set_root_clk_sel_rc32() {
+    unsafe { &*pac::HBN::ptr() }
+        .hbn_glb
+        .modify(|_, w| unsafe { w.hbn_root_clk_sel().bits(0b00u8) });
 }
 
-fn pds_enable_pll_all_clks(){
-    unsafe { &*pac::PDS::ptr() }.clkpll_output_en.modify(|r, w| unsafe {w
-        .bits(r.bits() | 0x1FF)
-    });
+fn pds_enable_pll_all_clks() {
+    unsafe { &*pac::PDS::ptr() }
+        .clkpll_output_en
+        .modify(|r, w| unsafe { w.bits(r.bits() | 0x1FF) });
 }
 
 /// Sets the system clock to use the internal 32Mhz RC oscillator
-fn glb_set_system_clk_rc32(){
+fn glb_set_system_clk_rc32() {
     // reg_bclk_en = reg_hclk_en = reg_fclk_en = 1, cannot be zero
-    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| { w
-        .reg_bclk_en().set_bit()
-        .reg_hclk_en().set_bit()
-        .reg_fclk_en().set_bit()
+    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| {
+        w.reg_bclk_en()
+            .set_bit()
+            .reg_hclk_en()
+            .set_bit()
+            .reg_fclk_en()
+            .set_bit()
     });
 
     // Before config XTAL and PLL, make sure root clk is from RC32M
     hbn_set_root_clk_sel_rc32();
 
-    glb_set_system_clk_div(0,0);
+    glb_set_system_clk_div(0, 0);
 
     // Update sysclock
     system_core_clock_set(RC32M);
 
     // Select PKA clock from hclk
-    unsafe { &*pac::GLB::ptr() }.swrst_cfg2.modify(|_, w| { w
-        .pka_clk_sel().clear_bit()
-    });
+    unsafe { &*pac::GLB::ptr() }
+        .swrst_cfg2
+        .modify(|_, w| w.pka_clk_sel().clear_bit());
 }
 
 /// Sets the system clock to use the PLL with external crystal
@@ -472,25 +491,25 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     delay.try_delay_us(55).unwrap();
 
     pds_enable_pll_all_clks();
-    
-    // Enable PLL
-    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| {w
-        .reg_pll_en().set_bit()
-    });
 
-    // select which pll output clock to use before 
+    // Enable PLL
+    unsafe { &*pac::GLB::ptr() }
+        .clk_cfg0
+        .modify(|_, w| w.reg_pll_en().set_bit());
+
+    // select which pll output clock to use before
     // selecting root clock via HBN_Set_ROOT_CLK_Sel
     // Note that 192Mhz is out of spec
-    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| unsafe {w
-        .reg_pll_sel().bits(
-            match target_core_clk {
-                48_000_000 => 0,
-                120_000_000 => 1,
-                160_000_000 => 2,
-                192_000_000 => 3,
-                _ => {panic!()}
+    unsafe { &*pac::GLB::ptr() }.clk_cfg0.modify(|_, w| unsafe {
+        w.reg_pll_sel().bits(match target_core_clk {
+            48_000_000 => 0,
+            120_000_000 => 1,
+            160_000_000 => 2,
+            192_000_000 => 3,
+            _ => {
+                panic!()
             }
-        )
+        })
     });
 
     // Keep bclk <= 80MHz
@@ -500,21 +519,21 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
 
     // For frequencies above 120Mhz we need 2 clocks to access internal rom
     if target_core_clk > 120_000_000 {
-        unsafe { &*pac::L1C::ptr() }.l1c_config.modify(|_, w| {w
-            .irom_2t_access().set_bit()
-        });
+        unsafe { &*pac::L1C::ptr() }
+            .l1c_config
+            .modify(|_, w| w.irom_2t_access().set_bit());
     }
 
     hbn_set_root_clk_sel_pll();
     system_core_clock_set(target_core_clk);
-    
+
     let mut delay = McycleDelay::new(system_core_clock_get());
     // This delay used to be 8 NOPS (1/4 us). (GLB_CLK_SET_DUMMY_WAIT) Might need to be replaced again.
     delay.try_delay_us(1).unwrap();
 
     // use 120Mhz PLL tap for PKA clock since we're using PLL
     // NOTE: This isn't documented in the datasheet!
-    unsafe { &*pac::GLB::ptr() }.swrst_cfg2.modify(|_, w| { w
-        .pka_clk_sel().set_bit()
-    });
+    unsafe { &*pac::GLB::ptr() }
+        .swrst_cfg2
+        .modify(|_, w| w.pka_clk_sel().set_bit());
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -26,6 +26,10 @@ use embedded_time::rate::Hertz;
 use crate::pac::Peripherals;
 use embedded_hal::blocking::delay::{DelayUs};
 use crate::delay::*;
+
+/// Internal high-speed RC oscillator frequency
+pub const RC32M: u32 = 32_000_000;
+
 pub struct Clocks {
     pll_xtal_freq: u32,
     sysclk: u32,
@@ -36,7 +40,7 @@ impl Clocks {
     pub fn new() -> Self {
         Clocks {
             pll_xtal_freq: 0,
-            sysclk: 32_000_000,
+            sysclk: RC32M,
             uart_clk_div: 0,
         }
     }
@@ -145,7 +149,7 @@ impl Strict {
         // Default to not using the PLL, and selecting the internal RC oscillator if nothing selected
         // TODO: verify clocks
         let pll_xtal_freq = self.pll_xtal_freq.unwrap_or(0);
-        let sysclk = self.sysclk.unwrap_or(32_000_000);
+        let sysclk = self.sysclk.unwrap_or(RC32M);
 
         // UART config
         // TODO: use 160_000_000 only when sourced from PLL, otherwise sysclk
@@ -395,7 +399,7 @@ fn glb_set_system_clk_rc32(){
     });
 
     // Update sysclock
-    system_core_clock_set(32_000_000);
+    system_core_clock_set(RC32M);
 
     // Select PKA clock from hclk
     glb.swrst_cfg2.modify(|_, w| { w
@@ -413,7 +417,7 @@ pub fn glb_set_system_clk(xtal_freq: u32, sysclk_freq: u32) {
     // Ensure clock is running off internal RC oscillator before changing anything else
     glb_set_system_clk_rc32();
     // if target clock is 32Mhz we don't have to do any more
-    if sysclk_freq == 32_000_000{
+    if sysclk_freq == RC32M{
         return
     } else {
         // Configure XTAL, PLL and select it as clock source for fclk

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -72,17 +72,7 @@ pub fn SystemCoreClockGet(dp: &mut Peripherals) -> u32 {
 }
 
 fn glb_set_system_clk_div(dp: &mut Peripherals, hclkdiv:u8, bclkdiv:u8){
-    // uint32_t tmpVal;
-
     // /* recommended: fclk<=160MHz, bclk<=80MHz */
-    // tmpVal=BL_RD_REG(GLB_BASE,GLB_CLK_CFG0);
-    // tmpVal=BL_SET_REG_BITS_VAL(tmpVal,GLB_REG_HCLK_DIV,hclkDiv);
-    // tmpVal=BL_SET_REG_BITS_VAL(tmpVal,GLB_REG_BCLK_DIV,bclkDiv);
-    // BL_WR_REG(GLB_BASE,GLB_CLK_CFG0,tmpVal);
-    // GLB_REG_BCLK_DIS_TRUE;
-    // GLB_REG_BCLK_DIS_FALSE;
-    // SystemCoreClockSet(SystemCoreClockGet()/((uint16_t)hclkDiv+1));
-
     let glb_reg_bclk_dis = 0x40000FFC as * mut u32;
     dp.GLB.clk_cfg0.modify(|_,w| unsafe { w
         .reg_hclk_div().bits(hclkdiv)
@@ -93,25 +83,17 @@ fn glb_set_system_clk_div(dp: &mut Peripherals, hclkdiv:u8, bclkdiv:u8){
     let currclock = SystemCoreClockGet(dp);
     SystemCoreClockSet(dp, currclock / (hclkdiv as u32 + 1) );
 
-    // // GLB_CLK_SET_DUMMY_WAIT;
     // // This was a set of 8 NOP instructions. at 32mhz, this is 1/4 of a us
     // // but since we just changed our clock source, we'll wait the equivalent of 1us worth
     // // of clocks at 160Mhz (this *should* be much longer than necessary)
     let mut delay = McycleDelay::new(SystemCoreClockGet(dp));
     delay.try_delay_us(1).unwrap();
 
-
-    // tmpVal=BL_RD_REG(GLB_BASE,GLB_CLK_CFG0);
-    // tmpVal=BL_SET_REG_BIT(tmpVal,GLB_REG_HCLK_EN);
-    // tmpVal=BL_SET_REG_BIT(tmpVal,GLB_REG_BCLK_EN);
-    // BL_WR_REG(GLB_BASE,GLB_CLK_CFG0,tmpVal);
-    // GLB_CLK_SET_DUMMY_WAIT;
     dp.GLB.clk_cfg0.modify(|_,w| unsafe { w
         .reg_hclk_en().set_bit()
         .reg_bclk_en().set_bit()
     });
     delay.try_delay_us(1).unwrap();
-    // return SUCCESS;
 }
 
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -266,40 +266,28 @@ fn pds_power_on_pll(dp: &mut Peripherals, xtal: GLB_PLL_XTAL_Type) {
     //DelayUs(5);
     delay.try_delay_us(5).unwrap();
 
-    // /* clkpll_sdm_reset=1 */
-    // tmpVal=BL_RD_REG(PDS_BASE,PDS_PU_RST_CLKPLL);
-    // tmpVal=BL_SET_REG_BIT(tmpVal,PDS_CLKPLL_SDM_RESET);
-    // BL_WR_REG(PDS_BASE,PDS_PU_RST_CLKPLL,tmpVal);
+    /* clkpll_sdm_reset=1 */
     dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
         .clkpll_sdm_reset().set_bit()
     });
     // BL602_Delay_US(1);
     delay.try_delay_us(1).unwrap();
 
-    // /* clkpll_reset_fbdv=1 */
-    // tmpVal=BL_RD_REG(PDS_BASE,PDS_PU_RST_CLKPLL);
-    // tmpVal=BL_SET_REG_BIT(tmpVal,PDS_CLKPLL_RESET_FBDV);
-    // BL_WR_REG(PDS_BASE,PDS_PU_RST_CLKPLL,tmpVal);
+    /* clkpll_reset_fbdv=1 */
     dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
         .clkpll_reset_fbdv().set_bit()
     });
     // BL602_Delay_US(2);
     delay.try_delay_us(2).unwrap();
 
-    // /* clkpll_reset_fbdv=0 */
-    // tmpVal=BL_RD_REG(PDS_BASE,PDS_PU_RST_CLKPLL);
-    // tmpVal=BL_CLR_REG_BIT(tmpVal,PDS_CLKPLL_RESET_FBDV);
-    // BL_WR_REG(PDS_BASE,PDS_PU_RST_CLKPLL,tmpVal);
+    /* clkpll_reset_fbdv=0 */
     dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
         .clkpll_reset_fbdv().clear_bit()
     });
     // BL602_Delay_US(1);
     delay.try_delay_us(1).unwrap();
 
-    // /* clkpll_sdm_reset=0 */
-    // tmpVal=BL_RD_REG(PDS_BASE,PDS_PU_RST_CLKPLL);
-    // tmpVal=BL_CLR_REG_BIT(tmpVal,PDS_CLKPLL_SDM_RESET);
-    // BL_WR_REG(PDS_BASE,PDS_PU_RST_CLKPLL,tmpVal);
+    /* clkpll_sdm_reset=0 */
     dp.PDS.pu_rst_clkpll.modify(|_r, w| unsafe {w
         .clkpll_sdm_reset().clear_bit()
     });
@@ -337,17 +325,12 @@ fn hbn_set_root_clk_sel(dp: &mut Peripherals, sel: HBN_ROOT_CLK_Type){
 /// TODO: finish clock init - some parts are hard-coded for 40Mhz XTAL + 160Mhz target clock
 pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GLB_PLL_XTAL_Type, clk: sys_clk) {
     /* reg_bclk_en = reg_hclk_en = reg_fclk_en = 1, cannot be zero */
-    // tmpVal = BL_SET_REG_BIT(tmpVal,GLB_REG_BCLK_EN);
-    // tmpVal = BL_SET_REG_BIT(tmpVal,GLB_REG_HCLK_EN);
-    // tmpVal = BL_SET_REG_BIT(tmpVal,GLB_REG_FCLK_EN);
-    // BL_WR_REG(GLB_BASE,GLB_CLK_CFG0,tmpVal);
     dp.GLB.clk_cfg0.modify(|_, w| unsafe { w
         .reg_bclk_en().set_bit()
         .reg_hclk_en().set_bit()
         .reg_fclk_en().set_bit()
     });
 
-    //HBN_Set_ROOT_CLK_Sel(HBN_ROOT_CLK_RC32M)
      /* Before config XTAL and PLL ,make sure root clk is from RC32M */
     hbn_set_root_clk_sel(dp, HBN_ROOT_CLK_Type::RC32M);
 
@@ -438,14 +421,14 @@ pub fn glb_set_system_clk(dp: &mut Peripherals, xtal: GLB_PLL_XTAL_Type, clk: sy
         _ => {}
     };
 
-    // // GLB_CLK_SET_DUMMY_WAIT;
-    // // This was a set of 8 NOP instructions. at 32mhz, this is 1/4 of a us
-    // // but since we just changed our clock source, we'll wait the equivalent of 1us worth
-    // // of clocks at 160Mhz (this *should* be much longer than necessary)
+    // GLB_CLK_SET_DUMMY_WAIT;
+    // This was a set of 8 NOP instructions. at 32mhz, this is 1/4 of a us
+    // but since we just changed our clock source, we'll wait the equivalent of 1us worth
+    // of clocks at 160Mhz (this *should* be much longer than necessary)
     let mut delay = McycleDelay::new(SystemCoreClockGet(dp));
     delay.try_delay_us(1).unwrap();
 
-    // /* select PKA clock from 120M since we power up PLL */
+    /* select PKA clock from 120M since we power up PLL */
     // NOTE: This isn't documented in the datasheet!
     // GLB_Set_PKA_CLK_Sel(GLB_PKA_CLK_PLL120M);
     dp.GLB.swrst_cfg2.write(|w| unsafe { w

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -44,9 +44,9 @@ pub struct Strict {
 #[allow(dead_code)]
 #[repr(u8)]
 enum HbnRootClkType {
-    RC32M = 0,           // use RC32M as root clock
-    XTAL  = 1,           // use XTAL as root clock
-    PLL   = 2,           // use PLL as root clock
+    Rc32m = 0,           // use RC32M as root clock
+    Xtal  = 1,           // use XTAL as root clock
+    Pll   = 2,           // use PLL as root clock
 }
 
 /**
@@ -323,9 +323,9 @@ fn hbn_set_root_clk_sel(sel: HbnRootClkType){
     hbn.hbn_glb.modify(|r,w| unsafe { w
         .hbn_root_clk_sel().bits(
             match sel {
-                HbnRootClkType::RC32M => 0b00u8,
-                HbnRootClkType::XTAL => 0b01u8,
-                HbnRootClkType::PLL => r.hbn_root_clk_sel().bits() as u8 | 0b10u8
+                HbnRootClkType::Rc32m => 0b00u8,
+                HbnRootClkType::Xtal => 0b01u8,
+                HbnRootClkType::Pll => r.hbn_root_clk_sel().bits() as u8 | 0b10u8
             }
         )
     });
@@ -350,7 +350,7 @@ pub fn glb_set_system_clk(xtal: GlbPllXtalType, clk: SysClk) {
     });
 
      /* Before config XTAL and PLL ,make sure root clk is from RC32M */
-    hbn_set_root_clk_sel(HbnRootClkType::RC32M);
+    hbn_set_root_clk_sel(HbnRootClkType::Rc32m);
 
     glb.clk_cfg0.modify(|_,w| unsafe { w
         .reg_hclk_div().bits(0)
@@ -429,7 +429,7 @@ pub fn glb_set_system_clk(xtal: GlbPllXtalType, clk: SysClk) {
         });
     }
     if target_core_clk > 0 {
-        hbn_set_root_clk_sel(HbnRootClkType::PLL);
+        hbn_set_root_clk_sel(HbnRootClkType::Pll);
         system_core_clock_set(target_core_clk);
     }
 
@@ -491,7 +491,7 @@ impl Strict {
             .uart_clk_en().set_bit()
         });
 
-        let target_clksrc = HbnRootClkType::PLL;
+        let target_clksrc = HbnRootClkType::Pll;
         let pll_xtal = GlbPllXtalType::Xtal40m;
         let target_sys_ck = SysClk::Pll160m;
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -180,18 +180,6 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
                 .clkpll_icp_5u().bits(0)
                 .clkpll_int_frac_sw().set_bit()
             });
-        },
-        _ => {
-            pds.clkpll_cp.modify(|_r, w| unsafe {w
-                .clkpll_icp_1u().bits(0)
-                .clkpll_icp_5u().bits(2)
-                .clkpll_int_frac_sw().clear_bit()
-            });
-        }
-    }
-
-    match xtal {
-        GlbPllXtalType::Xtal26m => {
             pds.clkpll_rz.modify(|_r, w| unsafe {w
                 .clkpll_c3().bits(2)
                 .clkpll_cz().bits(2)
@@ -200,6 +188,11 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
             });
         },
         _ => {
+            pds.clkpll_cp.modify(|_r, w| unsafe {w
+                .clkpll_icp_1u().bits(0)
+                .clkpll_icp_5u().bits(2)
+                .clkpll_int_frac_sw().clear_bit()
+            });
             pds.clkpll_rz.modify(|_r, w| unsafe {w
                 .clkpll_c3().bits(3)
                 .clkpll_cz().bits(1)
@@ -208,6 +201,7 @@ fn pds_power_on_pll(xtal: GlbPllXtalType) {
             });
         }
     }
+
     pds.clkpll_top_ctrl.modify(|_r, w| unsafe {w
         .clkpll_postdiv().bits(0x14)
         .clkpll_refdiv_ratio().bits(2)

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -386,7 +386,7 @@ fn pds_power_on_pll(freq: u32) {
     });
 }
 
-fn aon_power_on_xtal() {
+fn aon_power_on_xtal() -> Result<(), &'static str> {
     unsafe { &*pac::AON::ptr() }.rf_top_aon.modify(|_, w| { w
         .pu_xtal_aon().set_bit()
         .pu_xtal_buf_aon().set_bit()
@@ -399,7 +399,11 @@ fn aon_power_on_xtal() {
         delaysrc.try_delay_us(10).unwrap();
         timeout+=1;
     }
-    // TODO: error out on timeout
+    if timeout == 120 {
+        Err("timeout occured")
+    } else {
+        Ok(())
+    }
 }
 
 fn hbn_set_root_clk_sel_pll(){
@@ -450,7 +454,7 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     // Ensure clock is running off internal RC oscillator before changing anything else
     glb_set_system_clk_rc32();
     // Power up the external crystal before we start up the PLL
-    aon_power_on_xtal();
+    aon_power_on_xtal().unwrap();
 
     // Power up PLL and enable all PLL clock output
     pds_power_on_pll_rom(xtal_freq);

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -45,7 +45,7 @@ impl Clocks {
 
     pub fn freeze(self) -> Clocks {
         let glb = unsafe { &*pac::GLB::ptr() };
-        glb.clk_cfg2.write(|w| unsafe { w
+        glb.clk_cfg2.modify(|_, w| unsafe { w
             .uart_clk_div().bits(self.uart_clk_div-1)
             .uart_clk_en().set_bit()
         });
@@ -458,7 +458,7 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
 
     // use 120Mhz PLL tap for PKA clock since we're using PLL
     // NOTE: This isn't documented in the datasheet!
-    glb.swrst_cfg2.write(|w| { w
+    glb.swrst_cfg2.modify(|_, w| { w
         .pka_clk_sel().set_bit()
     });
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -33,6 +33,8 @@ use crate::delay::*;
 
 /// Internal high-speed RC oscillator frequency
 pub const RC32M: u32 = 32_000_000;
+/// UART peripheral clock frequency when PLL selected
+pub const UART_PLL_FREQ: u32 = 160_000_000;
 
 /// Frozen clock frequencies
 ///
@@ -149,7 +151,7 @@ impl Strict {
         let uart_clk =  self.target_uart_clk.map(|f| f.get()).unwrap_or(sysclk);
         // If PLL is available we'll be using the PLL_160Mhz clock, otherwise sysclk
         let uart_clk_src = if pll_enabled {
-            160_000_000
+            UART_PLL_FREQ
         } else {
             sysclk
         };

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -261,7 +261,7 @@ fn pds_power_off_pll(){
 fn pds_power_on_pll_rom(freq: u32) {
     // Lookup table for ROM function addresses is at 0x21010800
     // offset for RomDriver_PDS_Power_On_PLL is 88
-    let power_on_pll_lut_entry = (0x21010800 + 88) as * mut u32;
+    let power_on_pll_lut_entry = (0x21010800 + 88) as * mut usize;
     let power_on_pll_addr = unsafe { power_on_pll_lut_entry.read_volatile() };
     let romdriver_pds_power_on_pll = unsafe { 
         core::mem::transmute::<*const(), extern "C" fn(usize)> (


### PR DESCRIPTION
I've ported some of the core clock initialization code from 
https://github.com/pine64/bl_iot_sdk and 
https://github.com/bouffalolab/bl_iot_sdk

Only the Strict API for clocks has been implemented. Still not 100% happy with the names in the API for Freeze, but they reasonably consistent with other HALs.

The private functions that implement the separate phases of initialization still have the same names as those in the SDK repos mentioned above. This was to make it easier to do side-by-side comparison to verify that they were functionally identical - this may help with review as well.

You can spin up the PLL independently of using it as the system clock, but if it's enabled it always gets used as the UART clock source.
I have tested the UART at a few frequencies while using different system clock frequencies. The CH340 on the Doiting module doesn't work well with all baud rates under Linux, other USB-UARTs/OSes may work better with arbitrary baud rates.