### PR TITLE
Add Github Actions CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+on: [push, pull_request]
+
+name: Continuous Integration
+
+jobs:
+  rust_check:
+    name: Rust check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Run checks on stable and nightly Rust
+        rust: [stable, nightly]
+
+        include:
+          # Run check with MSRV as well
+          - rust: 1.42.0
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,17 @@
+on: [push, pull_request]
+
+name: Clippy check
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds workflows for Github Actions with 2 workflows:

* **ci**: Runs `cargo check` on Rust `stable`, `nightly`, and our MSRV (`1.42.0`)
* **clippy**: runs `cargo clippy` on Rust stable

This is currently blocked by ~#6~ and #8 