### PR TITLE
Improve behaviour of uart::try_write and uart::try_flush

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -266,7 +266,7 @@ impl<PINS> embedded_hal::serial::Write<u8> for Serial<pac::UART, PINS> {
     fn try_flush(&mut self) -> nb::Result<(), Self::Error> {
         // If we're still transmitting or have data in our 32 byte FIFO, return WouldBlock
         if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() != 32
-            && self.uart.uart_status.read().sts_utx_bus_busy().bit_is_set()
+            || self.uart.uart_status.read().sts_utx_bus_busy().bit_is_set()
         {
             Err(nb::Error::WouldBlock)
         } else {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -252,15 +252,22 @@ impl<PINS> embedded_hal::serial::Write<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
     fn try_write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-        self.uart
-            .uart_fifo_wdata
-            .write(|w| unsafe { w.bits(word as u32) });
-
-        Ok(())
+        // If there's no room to write a byte or more to the FIFO, return WouldBlock
+        if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() == 0 {
+            Err(nb::Error::WouldBlock)
+        } else {
+            self.uart
+                .uart_fifo_wdata
+                .write(|w| unsafe { w.bits(word as u32) });
+            Ok(())
+        }
     }
 
     fn try_flush(&mut self) -> nb::Result<(), Self::Error> {
-        if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() < 1 {
+        // If we're still transmitting or have data in our 32 byte FIFO, return WouldBlock
+        if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() != 32
+            && self.uart.uart_status.read().sts_utx_bus_busy().bit_is_set()
+        {
             Err(nb::Error::WouldBlock)
         } else {
             Ok(())


### PR DESCRIPTION
try_write is supposed to return nb::Error::WouldBlock if it's not possible to write, but it was ignoring errors.
This PR changes it to return nb::Error::WouldBlock when the FIFO is full.

try_flush isn't very documented, but my intuition is that it's supposed to return nb::Error::WouldBlock until everything that was previously written has been fully transmitted (so you can safely turn off the UART peripheral, reset the device, etc)
My first attempt just checked if the FIFO had any data in it, but this would return Ok() when the last byte was still being transmitted.
The current solution is to return nb::Error::WouldBlock if the FIFO has bytes in it or the TX BUSY bit is set