### PR TITLE
SPI master implementation

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -232,7 +232,7 @@ impl Strict {
         let bus_clock = calculate_bus_clock();
         let spi_clk_div = bus_clock.0 / spi_clk;
 
-        if spi_clk_div == 0 || spi_clk_div > 0b11111 {
+        if spi_clk_div == 0 || spi_clk_div > 0b100000 {
             panic!("Unreachable SPI_CLK");
         }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -205,6 +205,9 @@ pub struct Output<MODE> {
 /// UART pin mode (type state)
 pub struct Uart;
 
+/// SPI pin mode (type state)
+pub struct Spi;
+
 #[doc(hidden)]
 pub trait UartPin<SIG> {}
 
@@ -341,7 +344,7 @@ macro_rules! impl_glb {
                     }
 
                     /// Configures the pin to SPI alternate mode
-                    pub fn [<into_spi_ $spi_kind>](self) -> $Pini<Uart> {
+                    pub fn [<into_spi_ $spi_kind>](self) -> $Pini<Spi> {
                         // 4 -> GPIO0_FUN_SPI_x
                         self.into_pin_with_mode(4, true, false, true)
                     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -213,7 +213,7 @@ pub trait UartPin<SIG> {}
 pub use self::pin::*;
 
 macro_rules! impl_glb {
-    ($($Pini: ident: ($pini: ident, $gpio_cfgctli: ident, $UartSigi: ident, $sigi: ident, $gpio_i: ident) ,)+) => {
+    ($($Pini: ident: ($pini: ident, $gpio_cfgctli: ident, $UartSigi: ident, $sigi: ident, $spi_kind: ident, $gpio_i: ident) ,)+) => {
         impl GlbExt for pac::GLB {
             fn split(self) -> Parts {
                 Parts {
@@ -339,6 +339,12 @@ macro_rules! impl_glb {
                         // 7 -> GPIO_FUN_UART
                         self.into_pin_with_mode(7, true, false, true)
                     }
+
+                    /// Configures the pin to SPI alternate mode
+                    pub fn [<into_spi_ $spi_kind>](self) -> $Pini<Uart> {
+                        // 4 -> GPIO0_FUN_SPI_x
+                        self.into_pin_with_mode(4, true, false, true)
+                    }
                 }
             }
 
@@ -409,27 +415,27 @@ macro_rules! impl_glb {
 // There are Pin0 to Pin22, totally 23 pins
 // todo: generate macros
 impl_glb! {
-    Pin0: (pin0, gpio_cfgctl0, UartSig0, sig0, gpio_0),
-    Pin1: (pin1, gpio_cfgctl0, UartSig1, sig1, gpio_1),
-    Pin2: (pin2, gpio_cfgctl1, UartSig2, sig2, gpio_2),
-    Pin3: (pin3, gpio_cfgctl1, UartSig3, sig3, gpio_3),
-    Pin4: (pin4, gpio_cfgctl2, UartSig4, sig4, gpio_4),
-    Pin5: (pin5, gpio_cfgctl2, UartSig5, sig5, gpio_5),
-    Pin6: (pin6, gpio_cfgctl3, UartSig6, sig6, gpio_6),
-    Pin7: (pin7, gpio_cfgctl3, UartSig7, sig7, gpio_7),
-    Pin8: (pin8, gpio_cfgctl4, UartSig0, sig0, gpio_8),
-    Pin9: (pin9, gpio_cfgctl4, UartSig1, sig1, gpio_9),
-    Pin10: (pin10, gpio_cfgctl5, UartSig2, sig2, gpio_10),
-    Pin11: (pin11, gpio_cfgctl5, UartSig3, sig3, gpio_11),
-    Pin12: (pin12, gpio_cfgctl6, UartSig4, sig4, gpio_12),
-    Pin13: (pin13, gpio_cfgctl6, UartSig5, sig5, gpio_13),
-    Pin14: (pin14, gpio_cfgctl7, UartSig6, sig6, gpio_14),
-    Pin15: (pin15, gpio_cfgctl7, UartSig7, sig7, gpio_15),
-    Pin16: (pin16, gpio_cfgctl8, UartSig0, sig0, gpio_16),
-    Pin17: (pin17, gpio_cfgctl8, UartSig1, sig1, gpio_17),
-    Pin18: (pin18, gpio_cfgctl9, UartSig2, sig2, gpio_18),
-    Pin19: (pin19, gpio_cfgctl9, UartSig3, sig3, gpio_19),
-    Pin20: (pin20, gpio_cfgctl10, UartSig4, sig4, gpio_20),
-    Pin21: (pin21, gpio_cfgctl10, UartSig5, sig5, gpio_21),
-    Pin22: (pin22, gpio_cfgctl11, UartSig6, sig6, gpio_22),
+    Pin0: (pin0, gpio_cfgctl0, UartSig0, sig0, miso, gpio_0),
+    Pin1: (pin1, gpio_cfgctl0, UartSig1, sig1, mosi, gpio_1),
+    Pin2: (pin2, gpio_cfgctl1, UartSig2, sig2, ss, gpio_2),
+    Pin3: (pin3, gpio_cfgctl1, UartSig3, sig3, sclk, gpio_3),
+    Pin4: (pin4, gpio_cfgctl2, UartSig4, sig4, miso, gpio_4),
+    Pin5: (pin5, gpio_cfgctl2, UartSig5, sig5, mosi, gpio_5),
+    Pin6: (pin6, gpio_cfgctl3, UartSig6, sig6, ss, gpio_6),
+    Pin7: (pin7, gpio_cfgctl3, UartSig7, sig7, sclk, gpio_7),
+    Pin8: (pin8, gpio_cfgctl4, UartSig0, sig0, miso, gpio_8),
+    Pin9: (pin9, gpio_cfgctl4, UartSig1, sig1, mosi, gpio_9),
+    Pin10: (pin10, gpio_cfgctl5, UartSig2, sig2, ss, gpio_10),
+    Pin11: (pin11, gpio_cfgctl5, UartSig3, sig3, sclk, gpio_11),
+    Pin12: (pin12, gpio_cfgctl6, UartSig4, sig4, miso, gpio_12),
+    Pin13: (pin13, gpio_cfgctl6, UartSig5, sig5, mosi, gpio_13),
+    Pin14: (pin14, gpio_cfgctl7, UartSig6, sig6, ss, gpio_14),
+    Pin15: (pin15, gpio_cfgctl7, UartSig7, sig7, sclk, gpio_15),
+    Pin16: (pin16, gpio_cfgctl8, UartSig0, sig0, miso, gpio_16),
+    Pin17: (pin17, gpio_cfgctl8, UartSig1, sig1, mosi, gpio_17),
+    Pin18: (pin18, gpio_cfgctl9, UartSig2, sig2, ss, gpio_18),
+    Pin19: (pin19, gpio_cfgctl9, UartSig3, sig3, sclk, gpio_19),
+    Pin20: (pin20, gpio_cfgctl10, UartSig4, sig4, miso, gpio_20),
+    Pin21: (pin21, gpio_cfgctl10, UartSig5, sig5, mosi, gpio_21),
+    Pin22: (pin22, gpio_cfgctl11, UartSig6, sig6, ss, gpio_22),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod clock;
 pub mod delay;
 pub mod gpio;
 pub mod serial;
+pub mod spi;
 
 /// HAL crate prelude
 pub mod prelude {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,198 @@
+use bl602_pac::SPI;
+use embedded_hal::spi::{FullDuplex, Mode};
+use embedded_time::rate::Hertz;
+
+use crate::pac;
+
+use crate::clock::Clocks;
+
+/// SPI error
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Overrun occurred
+    Overrun,
+    /// Mode fault occurred
+    ModeFault,
+    /// CRC error
+    Crc,
+}
+
+/// The bit format to send the data in
+#[derive(Debug, Clone, Copy)]
+pub enum SpiBitFormat {
+    /// Least significant bit first
+    LsbFirst,
+    /// Most significant bit first
+    MsbFirst,
+}
+
+/// MISO pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait MisoPin<SPI> {}
+
+/// MOSI pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait MosiPin<SPI> {}
+
+/// SS pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SsPin<SPI> {}
+
+/// SCLK pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SclkPin<SPI> {}
+
+/// Spi pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait Pins<SPI> {}
+
+unsafe impl<MODE> MisoPin<pac::SPI> for crate::gpio::Pin0<MODE> {}
+unsafe impl<MODE> MosiPin<pac::SPI> for crate::gpio::Pin1<MODE> {}
+unsafe impl<MODE> SsPin<pac::SPI> for crate::gpio::Pin2<MODE> {}
+unsafe impl<MODE> SclkPin<pac::SPI> for crate::gpio::Pin3<MODE> {}
+unsafe impl<MODE> MisoPin<pac::SPI> for crate::gpio::Pin4<MODE> {}
+unsafe impl<MODE> MosiPin<pac::SPI> for crate::gpio::Pin5<MODE> {}
+unsafe impl<MODE> SsPin<pac::SPI> for crate::gpio::Pin6<MODE> {}
+unsafe impl<MODE> SclkPin<pac::SPI> for crate::gpio::Pin7<MODE> {}
+unsafe impl<MODE> MisoPin<pac::SPI> for crate::gpio::Pin8<MODE> {}
+unsafe impl<MODE> MosiPin<pac::SPI> for crate::gpio::Pin9<MODE> {}
+unsafe impl<MODE> SsPin<pac::SPI> for crate::gpio::Pin10<MODE> {}
+unsafe impl<MODE> SclkPin<pac::SPI> for crate::gpio::Pin11<MODE> {}
+unsafe impl<MODE> MisoPin<pac::SPI> for crate::gpio::Pin12<MODE> {}
+unsafe impl<MODE> MosiPin<pac::SPI> for crate::gpio::Pin13<MODE> {}
+unsafe impl<MODE> SsPin<pac::SPI> for crate::gpio::Pin14<MODE> {}
+unsafe impl<MODE> SclkPin<pac::SPI> for crate::gpio::Pin15<MODE> {}
+unsafe impl<MODE> MisoPin<pac::SPI> for crate::gpio::Pin16<MODE> {}
+unsafe impl<MODE> MosiPin<pac::SPI> for crate::gpio::Pin17<MODE> {}
+unsafe impl<MODE> SsPin<pac::SPI> for crate::gpio::Pin18<MODE> {}
+unsafe impl<MODE> SclkPin<pac::SPI> for crate::gpio::Pin19<MODE> {}
+unsafe impl<MODE> MisoPin<pac::SPI> for crate::gpio::Pin20<MODE> {}
+unsafe impl<MODE> MosiPin<pac::SPI> for crate::gpio::Pin21<MODE> {}
+unsafe impl<MODE> SsPin<pac::SPI> for crate::gpio::Pin22<MODE> {}
+
+unsafe impl<MISO, MOSI, SS, SCLK> Pins<SPI> for (MISO, MOSI, SS, SCLK)
+where
+    MISO: MisoPin<SPI>,
+    MOSI: MosiPin<SPI>,
+    SS: SsPin<SPI>,
+    SCLK: SclkPin<SPI>,
+{
+}
+
+pub struct Spi<SPI, PINS> {
+    spi: SPI,
+    pins: PINS,
+}
+
+impl<PINS> Spi<pac::SPI, PINS>
+where
+    PINS: Pins<pac::SPI>,
+{
+    pub fn spi(spi: SPI, pins: PINS, mode: Mode, freq: Hertz<u32>, clocks: Clocks) -> Self
+    where
+        PINS: Pins<pac::SPI>,
+    {
+        let glb = unsafe { &*pac::GLB::ptr() };
+
+        glb.glb_parm
+            .modify(|_r, w| w.reg_spi_0_master_mode().set_bit());
+
+        let len = clocks.spi_clk().0 / freq.0;
+        if len > 0b11111 || len == 0 {
+            panic!("Cannot reach the desired SPI frequency");
+        }
+
+        // TODO the measured frequency of SCLK is half of what I configure
+        let len = ((len - 1) & 0b11111) as u8;
+        spi.spi_prd_0.modify(|_r, w| unsafe {
+            w.cr_spi_prd_s()
+                .bits(len)
+                .cr_spi_prd_p()
+                .bits(len)
+                .cr_spi_prd_d_ph_0()
+                .bits(len)
+                .cr_spi_prd_d_ph_1()
+                .bits(len)
+        });
+
+        spi.spi_prd_1
+            .modify(|_r, w| unsafe { w.cr_spi_prd_i().bits(len) });
+
+        spi.spi_config.modify(|_, w| unsafe {
+            w.cr_spi_sclk_pol()
+                .bit(match mode.polarity {
+                    embedded_hal::spi::Polarity::IdleLow => false,
+                    embedded_hal::spi::Polarity::IdleHigh => true,
+                })
+                .cr_spi_sclk_ph()
+                .bit(match mode.phase {
+                    embedded_hal::spi::Phase::CaptureOnFirstTransition => false,
+                    embedded_hal::spi::Phase::CaptureOnSecondTransition => true,
+                })
+                .cr_spi_m_cont_en()
+                .clear_bit() // disable cont mode
+                .cr_spi_frame_size()
+                .bits(0) // 8 bit frames
+                .cr_spi_s_en()
+                .clear_bit() // not slave
+                .cr_spi_m_en()
+                .set_bit() // master
+        });
+
+        Spi { spi, pins }
+    }
+
+    pub fn free(self) -> (pac::SPI, PINS) {
+        // todo!
+        (self.spi, self.pins)
+    }
+
+    pub fn clear_fifo(&mut self) {
+        self.spi
+            .spi_fifo_config_0
+            .write(|w| w.rx_fifo_clr().set_bit().tx_fifo_clr().set_bit());
+    }
+}
+
+impl<PINS> FullDuplex<u8> for Spi<pac::SPI, PINS>
+where
+    PINS: Pins<pac::SPI>,
+{
+    type Error = Error;
+
+    fn try_read(&mut self) -> nb::Result<u8, Error> {
+        if self.spi.spi_fifo_config_1.read().rx_fifo_cnt().bits() == 0 {
+            Err(nb::Error::WouldBlock)
+        } else {
+            Ok((self.spi.spi_fifo_rdata.read().bits() & 0xff) as u8)
+        }
+    }
+
+    fn try_send(&mut self, data: u8) -> nb::Result<(), Self::Error> {
+        if self.spi.spi_fifo_config_1.read().tx_fifo_cnt().bits() == 0 {
+            Err(nb::Error::WouldBlock)
+        } else {
+            self.spi
+                .spi_fifo_wdata
+                .write(|w| unsafe { w.bits(data as u32) });
+
+            Ok(())
+        }
+    }
+}
+
+impl<PINS> embedded_hal::blocking::spi::transfer::Default<u8> for Spi<pac::SPI, PINS> where
+    PINS: Pins<pac::SPI>
+{
+}
+
+impl<PINS> embedded_hal::blocking::spi::write::Default<u8> for Spi<pac::SPI, PINS> where
+    PINS: Pins<pac::SPI>
+{
+}
+
+impl<PINS> embedded_hal::blocking::spi::write_iter::Default<u8> for Spi<pac::SPI, PINS> where
+    PINS: Pins<pac::SPI>
+{
+}
+
+impl<PINS> embedded_hal::blocking::spi::transactional::Default<u8> for Spi<pac::SPI, PINS> where
+    PINS: Pins<pac::SPI>
+{
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -161,8 +161,8 @@ where
                 })
                 .cr_spi_sclk_ph()
                 .bit(match mode.phase {
-                    embedded_hal::spi::Phase::CaptureOnFirstTransition => false,
-                    embedded_hal::spi::Phase::CaptureOnSecondTransition => true,
+                    embedded_hal::spi::Phase::CaptureOnFirstTransition => true,
+                    embedded_hal::spi::Phase::CaptureOnSecondTransition => false,
                 })
                 .cr_spi_m_cont_en()
                 .clear_bit() // disable cont mode

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -75,6 +75,14 @@ where
 {
 }
 
+unsafe impl<MISO, MOSI, SCLK> Pins<SPI> for (MISO, MOSI, SCLK)
+where
+    MISO: MisoPin<SPI>,
+    MOSI: MosiPin<SPI>,
+    SCLK: SclkPin<SPI>,
+{
+}
+
 pub struct Spi<SPI, PINS> {
     spi: SPI,
     pins: PINS,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -133,7 +133,7 @@ where
             .modify(|_r, w| w.reg_spi_0_master_mode().set_bit());
 
         let len = clocks.spi_clk().0 / freq.0;
-        if len > 255 || len == 0 {
+        if len > 256 || len == 0 {
             panic!("Cannot reach the desired SPI frequency");
         }
 


### PR DESCRIPTION
This adds SPI master functionality. (Only 8 bit transfers for now)

I tested this with a logic analyzer, loop back and an STM32F103 as SPI slave. It actually works so far but the SCLK frequency is half of what I configure - maybe someone sees where that problem is.  

See https://github.com/bjoernQ/bl602-hal/blob/df148c17aed4ad76b7f42f6277a36d3cf3e640e7/src/spi.rs#L140

I was also not able to test with advanced clock settings since my currently only DT-BL10 seems to be somewhat faulty and acts weird in some regards. (More dev boards are ordered but they did not arrive yet)
