### PR TITLE
Implement I2C

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -208,6 +208,9 @@ pub struct Uart;
 /// SPI pin mode (type state)
 pub struct Spi;
 
+/// I2C pin mode (type state)
+pub struct I2c;
+
 #[doc(hidden)]
 pub trait UartPin<SIG> {}
 
@@ -216,7 +219,7 @@ pub trait UartPin<SIG> {}
 pub use self::pin::*;
 
 macro_rules! impl_glb {
-    ($($Pini: ident: ($pini: ident, $gpio_cfgctli: ident, $UartSigi: ident, $sigi: ident, $spi_kind: ident, $gpio_i: ident) ,)+) => {
+    ($($Pini: ident: ($pini: ident, $gpio_cfgctli: ident, $UartSigi: ident, $sigi: ident, $spi_kind: ident, $i2c_kind: ident, $gpio_i: ident) ,)+) => {
         impl GlbExt for pac::GLB {
             fn split(self) -> Parts {
                 Parts {
@@ -348,6 +351,12 @@ macro_rules! impl_glb {
                         // 4 -> GPIO0_FUN_SPI_x
                         self.into_pin_with_mode(4, true, false, true)
                     }
+
+                    /// Configures the pin to I2C alternate mode
+                    pub fn [<into_i2c_ $i2c_kind>](self) -> $Pini<I2c> {
+                        // 6 -> GPIO_FUN_I2C_x
+                        self.into_pin_with_mode(6, true, false, true)
+                    }
                 }
             }
 
@@ -418,27 +427,27 @@ macro_rules! impl_glb {
 // There are Pin0 to Pin22, totally 23 pins
 // todo: generate macros
 impl_glb! {
-    Pin0: (pin0, gpio_cfgctl0, UartSig0, sig0, miso, gpio_0),
-    Pin1: (pin1, gpio_cfgctl0, UartSig1, sig1, mosi, gpio_1),
-    Pin2: (pin2, gpio_cfgctl1, UartSig2, sig2, ss, gpio_2),
-    Pin3: (pin3, gpio_cfgctl1, UartSig3, sig3, sclk, gpio_3),
-    Pin4: (pin4, gpio_cfgctl2, UartSig4, sig4, miso, gpio_4),
-    Pin5: (pin5, gpio_cfgctl2, UartSig5, sig5, mosi, gpio_5),
-    Pin6: (pin6, gpio_cfgctl3, UartSig6, sig6, ss, gpio_6),
-    Pin7: (pin7, gpio_cfgctl3, UartSig7, sig7, sclk, gpio_7),
-    Pin8: (pin8, gpio_cfgctl4, UartSig0, sig0, miso, gpio_8),
-    Pin9: (pin9, gpio_cfgctl4, UartSig1, sig1, mosi, gpio_9),
-    Pin10: (pin10, gpio_cfgctl5, UartSig2, sig2, ss, gpio_10),
-    Pin11: (pin11, gpio_cfgctl5, UartSig3, sig3, sclk, gpio_11),
-    Pin12: (pin12, gpio_cfgctl6, UartSig4, sig4, miso, gpio_12),
-    Pin13: (pin13, gpio_cfgctl6, UartSig5, sig5, mosi, gpio_13),
-    Pin14: (pin14, gpio_cfgctl7, UartSig6, sig6, ss, gpio_14),
-    Pin15: (pin15, gpio_cfgctl7, UartSig7, sig7, sclk, gpio_15),
-    Pin16: (pin16, gpio_cfgctl8, UartSig0, sig0, miso, gpio_16),
-    Pin17: (pin17, gpio_cfgctl8, UartSig1, sig1, mosi, gpio_17),
-    Pin18: (pin18, gpio_cfgctl9, UartSig2, sig2, ss, gpio_18),
-    Pin19: (pin19, gpio_cfgctl9, UartSig3, sig3, sclk, gpio_19),
-    Pin20: (pin20, gpio_cfgctl10, UartSig4, sig4, miso, gpio_20),
-    Pin21: (pin21, gpio_cfgctl10, UartSig5, sig5, mosi, gpio_21),
-    Pin22: (pin22, gpio_cfgctl11, UartSig6, sig6, ss, gpio_22),
+    Pin0: (pin0, gpio_cfgctl0, UartSig0, sig0, miso, scl, gpio_0),
+    Pin1: (pin1, gpio_cfgctl0, UartSig1, sig1, mosi, sda, gpio_1),
+    Pin2: (pin2, gpio_cfgctl1, UartSig2, sig2, ss, scl, gpio_2),
+    Pin3: (pin3, gpio_cfgctl1, UartSig3, sig3, sclk, sda, gpio_3),
+    Pin4: (pin4, gpio_cfgctl2, UartSig4, sig4, miso, scl, gpio_4),
+    Pin5: (pin5, gpio_cfgctl2, UartSig5, sig5, mosi, sda, gpio_5),
+    Pin6: (pin6, gpio_cfgctl3, UartSig6, sig6, ss, scl, gpio_6),
+    Pin7: (pin7, gpio_cfgctl3, UartSig7, sig7, sclk, sda, gpio_7),
+    Pin8: (pin8, gpio_cfgctl4, UartSig0, sig0, miso, scl, gpio_8),
+    Pin9: (pin9, gpio_cfgctl4, UartSig1, sig1, mosi, sda, gpio_9),
+    Pin10: (pin10, gpio_cfgctl5, UartSig2, sig2, ss, scl, gpio_10),
+    Pin11: (pin11, gpio_cfgctl5, UartSig3, sig3, sclk, sda, gpio_11),
+    Pin12: (pin12, gpio_cfgctl6, UartSig4, sig4, miso, scl, gpio_12),
+    Pin13: (pin13, gpio_cfgctl6, UartSig5, sig5, mosi, sda, gpio_13),
+    Pin14: (pin14, gpio_cfgctl7, UartSig6, sig6, ss, scl, gpio_14),
+    Pin15: (pin15, gpio_cfgctl7, UartSig7, sig7, sclk, sda, gpio_15),
+    Pin16: (pin16, gpio_cfgctl8, UartSig0, sig0, miso, scl, gpio_16),
+    Pin17: (pin17, gpio_cfgctl8, UartSig1, sig1, mosi, sda, gpio_17),
+    Pin18: (pin18, gpio_cfgctl9, UartSig2, sig2, ss, scl, gpio_18),
+    Pin19: (pin19, gpio_cfgctl9, UartSig3, sig3, sclk, sda, gpio_19),
+    Pin20: (pin20, gpio_cfgctl10, UartSig4, sig4, miso, scl, gpio_20),
+    Pin21: (pin21, gpio_cfgctl10, UartSig5, sig5, mosi, sda, gpio_21),
+    Pin22: (pin22, gpio_cfgctl11, UartSig6, sig6, ss, scl, gpio_22),
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,311 @@
+/*!
+  # Inter-Integrated Circuit (I2C) bus
+  To construct the I2C instance use the `I2c::i2c` function.
+  The pin parameter is a tuple containing `(scl, sda)` which should be configured via `into_i2c_scl` and `into_i2c_sda`.
+
+  ## Initialisation example
+  ```rust
+    let scl = parts.pin4.into_i2c_scl();
+    let sda = parts.pin5.into_i2c_sda();
+
+    let mut i2c = hal::i2c::I2c::i2c(
+        dp.I2C,
+        (scl, sda),
+        100_000u32.Hz(),
+        clocks,
+    );
+    ```
+*/
+
+use bl602_pac::I2C;
+use embedded_hal::blocking;
+use embedded_time::rate::Hertz;
+
+use crate::{clock::Clocks, pac};
+
+/// I2C error
+#[derive(Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Rx overflow occurred
+    RxOverflow,
+    /// Rx underflow occurred
+    RxUnderflow,
+    /// Tx overflow occurred
+    TxOverflow,
+    /// Tx underflow occurred
+    TxUnderflow,
+    /// Timeout waiting for fifo occurred
+    Timeout,
+}
+
+/// SDA pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SdaPin<I2C> {}
+
+/// SCL pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait SclPin<I2C> {}
+
+/// I2C pins - DO NOT IMPLEMENT THIS TRAIT
+pub unsafe trait Pins<I2C> {}
+
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin0<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin1<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin2<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin3<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin4<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin5<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin6<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin7<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin8<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin9<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin10<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin11<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin12<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin13<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin14<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin15<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin16<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin17<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin18<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin19<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin20<MODE> {}
+unsafe impl<MODE> SdaPin<pac::I2C> for crate::gpio::Pin21<MODE> {}
+unsafe impl<MODE> SclPin<pac::I2C> for crate::gpio::Pin22<MODE> {}
+
+unsafe impl<SCL, SDA> Pins<I2C> for (SCL, SDA)
+where
+    SCL: SclPin<I2C>,
+    SDA: SdaPin<I2C>,
+{
+}
+
+/// I2C peripheral operating in master mode supporting seven bit addressing
+pub struct I2c<I2C, PINS> {
+    i2c: I2C,
+    pins: PINS,
+    timeout: u16,
+}
+
+impl<PINS> I2c<pac::I2C, PINS>
+where
+    PINS: Pins<pac::I2C>,
+{
+    /**
+      Constructs an I2C instance in master mode.
+      The pin parameter tuple (scl, sda) needs to be configured accordingly.
+
+      The frequency cannot be more than a quarter of the i2c clock frequency.
+
+      The I2C instance supports 7 bit addressing mode.
+    */
+    pub fn i2c(i2c: I2C, pins: PINS, freq: Hertz<u32>, clocks: Clocks) -> Self
+    where
+        PINS: Pins<pac::I2C>,
+    {
+        // length of phase 0,1,2 and 3
+        // needs to be divided by four
+        let len = clocks.i2c_clk().0 / freq.0 / 4;
+        if len > 256 || len <= 1 {
+            // from the RM: Note: This value should not be set to 8’d0, adjust source
+            // clock rate instead if higher I2C clock rate is required
+            panic!("Cannot reach the desired I2C frequency");
+        }
+
+        let len = (len - 1) as u8;
+
+        i2c.i2c_prd_start.modify(|_r, w| unsafe {
+            w.cr_i2c_prd_s_ph_0()
+                .bits(len)
+                .cr_i2c_prd_s_ph_1()
+                .bits(len)
+                .cr_i2c_prd_s_ph_2()
+                .bits(len)
+                .cr_i2c_prd_s_ph_3()
+                .bits(len)
+        });
+
+        i2c.i2c_prd_stop.modify(|_r, w| unsafe {
+            w.cr_i2c_prd_p_ph_0()
+                .bits(len)
+                .cr_i2c_prd_p_ph_1()
+                .bits(len)
+                .cr_i2c_prd_p_ph_2()
+                .bits(len)
+                .cr_i2c_prd_p_ph_3()
+                .bits(len)
+        });
+
+        i2c.i2c_prd_data.modify(|_r, w| unsafe {
+            w.cr_i2c_prd_d_ph_0()
+                .bits(len)
+                .cr_i2c_prd_d_ph_1()
+                .bits(len)
+                .cr_i2c_prd_d_ph_2()
+                .bits(len)
+                .cr_i2c_prd_d_ph_3()
+                .bits(len)
+        });
+
+        I2c {
+            i2c,
+            pins,
+            timeout: 255,
+        }
+    }
+
+    pub fn release(self) -> (pac::I2C, PINS) {
+        (self.i2c, self.pins)
+    }
+
+    /// Set the timeout when waiting for fifo (rx and tx).
+    /// It's not a time unit but the number of cycles to wait.
+    /// This defaults to 255
+    pub fn set_timeout(&mut self, timeout: u16) {
+        self.timeout = timeout;
+    }
+
+    /// Clear FIFOs
+    pub fn clear_fifo(&mut self) {
+        self.i2c
+            .i2c_fifo_config_0
+            .write(|w| w.rx_fifo_clr().set_bit().tx_fifo_clr().set_bit());
+    }
+}
+
+impl<PINS> blocking::i2c::Read<blocking::i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
+where
+    PINS: Pins<pac::I2C>,
+{
+    type Error = Error;
+
+    fn try_read(
+        &mut self,
+        address: blocking::i2c::SevenBitAddress,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        let fifo_config = self.i2c.i2c_fifo_config_0.read();
+
+        if fifo_config.rx_fifo_overflow().bit_is_set() {
+            return Err(Error::RxOverflow);
+        } else if fifo_config.rx_fifo_underflow().bit_is_set() {
+            return Err(Error::RxUnderflow);
+        }
+
+        let count = buffer.len() / 4 + if buffer.len() % 4 > 0 { 1 } else { 0 };
+        let mut word_buffer = [0u32; 255];
+        let tmp = &mut word_buffer[..count];
+
+        self.i2c.i2c_config.modify(|_r, w| unsafe {
+            w.cr_i2c_pkt_len()
+                .bits(buffer.len() as u8 - 1u8)
+                .cr_i2c_slv_addr()
+                .bits(address)
+                .cr_i2c_sub_addr_en()
+                .clear_bit()
+                .cr_i2c_sub_addr_bc()
+                .bits(0)
+                .cr_i2c_scl_sync_en()
+                .set_bit()
+                .cr_i2c_pkt_dir()
+                .set_bit() // = read
+                .cr_i2c_m_en()
+                .set_bit()
+        });
+
+        let mut timeout_countdown = self.timeout;
+        for value in tmp.iter_mut() {
+            while self.i2c.i2c_fifo_config_1.read().rx_fifo_cnt().bits() == 0 {
+                if timeout_countdown == 0 {
+                    return Err(Error::Timeout);
+                }
+                timeout_countdown -= 1;
+            }
+            *value = self.i2c.i2c_fifo_rdata.read().i2c_fifo_rdata().bits();
+        }
+
+        self.i2c
+            .i2c_config
+            .modify(|_r, w| w.cr_i2c_m_en().clear_bit());
+
+        for (idx, value) in buffer.iter_mut().enumerate() {
+            let shift_by = (idx % 4 * 8) as u32;
+            *value = (word_buffer[idx / 4].overflowing_shr(shift_by).0 & 0xff) as u8;
+        }
+
+        Ok(())
+    }
+}
+
+impl<PINS> blocking::i2c::Write<blocking::i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
+where
+    PINS: Pins<pac::I2C>,
+{
+    type Error = Error;
+
+    fn try_write(
+        &mut self,
+        address: blocking::i2c::SevenBitAddress,
+        buffer: &[u8],
+    ) -> Result<(), Self::Error> {
+        let fifo_config = self.i2c.i2c_fifo_config_0.read();
+
+        if fifo_config.tx_fifo_overflow().bit_is_set() {
+            return Err(Error::TxOverflow);
+        } else if fifo_config.tx_fifo_underflow().bit_is_set() {
+            return Err(Error::TxUnderflow);
+        }
+
+        let mut word_buffer = [0u32; 255];
+        let count = buffer.len() / 4 + if buffer.len() % 4 > 0 { 1 } else { 0 };
+        for (idx, value) in buffer.iter().enumerate() {
+            let shift_by = (idx % 4 * 8) as u32;
+            word_buffer[idx / 4] |= (*value as u32).overflowing_shl(shift_by).0;
+        }
+        let tmp = &word_buffer[..count];
+
+        self.i2c.i2c_config.modify(|_r, w| unsafe {
+            w.cr_i2c_pkt_len()
+                .bits(buffer.len() as u8 - 1u8)
+                .cr_i2c_slv_addr()
+                .bits(address)
+                .cr_i2c_sub_addr_en()
+                .clear_bit()
+                .cr_i2c_sub_addr_bc()
+                .bits(0)
+                .cr_i2c_scl_sync_en()
+                .set_bit()
+                .cr_i2c_pkt_dir()
+                .clear_bit() // = write
+                .cr_i2c_m_en()
+                .set_bit()
+        });
+
+        let mut timeout_countdown = self.timeout;
+        for value in tmp.iter() {
+            while self.i2c.i2c_fifo_config_1.read().tx_fifo_cnt().bits() == 0 {
+                if timeout_countdown == 0 {
+                    return Err(Error::Timeout);
+                }
+                timeout_countdown -= 1;
+            }
+            self.i2c
+                .i2c_fifo_wdata
+                .modify(|_r, w| unsafe { w.i2c_fifo_wdata().bits(*value as u32) });
+        }
+
+        while self
+            .i2c
+            .i2c_bus_busy
+            .read()
+            .cr_i2c_bus_busy_clr()
+            .bit_is_set()
+        {
+            // wait for transfer to finish
+        }
+
+        self.i2c
+            .i2c_config
+            .modify(|_r, w| w.cr_i2c_m_en().clear_bit());
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod checksum;
 pub mod clock;
 pub mod delay;
 pub mod gpio;
+pub mod i2c;
 pub mod serial;
 pub mod spi;
 


### PR DESCRIPTION
This implements I2C functionality.

- implements Read and Write traits since I don't see how / if the BL602 i2c peripheral can support the contract of Transactional
- supports 7 bit addressing

I tested this with an SSD1306 (just set all pixels on and the display on / off in a loop) and communicating with an BMP180 sensor. Worked for me and looks fine when inspecting the communication with a logic analyzer.
