### PR TITLE
Replace reg.modify() with reg.write() on WO registers

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -289,7 +289,7 @@ where
             }
             self.i2c
                 .i2c_fifo_wdata
-                .modify(|_r, w| unsafe { w.i2c_fifo_wdata().bits(*value as u32) });
+                .write(|w| unsafe { w.i2c_fifo_wdata().bits(*value as u32) });
         }
 
         while self

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -176,21 +176,24 @@ macro_rules! impl_timer_channel {
                 }
 
                 /// Clear interrupt for match register 0.
+                /// TICR register is write-only, no need to preserve register contents
                 pub fn clear_match0_interrupt(&self) {
                     let timer = unsafe { &*pac::TIMER::ptr() };
-                    timer.[<ticr $channel>].modify(|_r, w| w.tclr_0().set_bit());
+                    timer.[<ticr $channel>].write(|w| w.tclr_0().set_bit());
                 }
 
                 /// Clear interrupt for match register 1.
+                /// TICR register is write-only, no need to preserve register contents
                 pub fn clear_match1_interrupt(&self) {
                     let timer = unsafe { &*pac::TIMER::ptr() };
-                    timer.[<ticr $channel>].modify(|_r, w| w.tclr_1().set_bit());
+                    timer.[<ticr $channel>].write(|w| w.tclr_1().set_bit());
                 }
 
                 /// Clear interrupt for match register 2.
+                /// TICR register is write-only, no need to preserve register contents
                 pub fn clear_match2_interrupt(&self) {
                     let timer = unsafe { &*pac::TIMER::ptr() };
-                    timer.[<ticr $channel>].modify(|_r, w| w.tclr_2().set_bit());
+                    timer.[<ticr $channel>].write(|w| w.tclr_2().set_bit());
                 }
 
                 /// Sets when the to preload.


### PR DESCRIPTION
While migrating to new the new PAC, a few registers were flagged as invalid for modify access as the registers are Write Only.

Writing i2c_fifo_wdata has the same behavior as previous to this PR. The register is 32bits wide, we were writing 32bits and ignoring read value

The interrupt clear registers auto-clear as far as I can tell via the Reference Manual, so we should not need to manually preserve their contents

Attached are snippets of RM 1.2 for verifying these changes
![i2c_wdata](https://user-images.githubusercontent.com/60134748/115951790-079cf800-a526-11eb-897d-24413a556859.png)
![TICR2](https://user-images.githubusercontent.com/60134748/115951794-09ff5200-a526-11eb-8f98-caaf8fbae61a.png)
![TICR3](https://user-images.githubusercontent.com/60134748/115951796-0c61ac00-a526-11eb-9986-1ee1b5ed6f92.png)
