### PR TITLE
Pin to previous EH alpha to fix builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "HAL for the bl602 microcontroller"
 
 [dependencies]
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
-embedded-hal = "1.0.0-alpha.4"
+embedded-hal = "=1.0.0-alpha.4"
 embedded-time = "0.12.0"
 riscv = "0.6.0"
 nb = "1.0"


### PR DESCRIPTION
Since we didn't have the version pinned new users get alpha.5
Pin to alpha.4 until we've upgraded to the new traits.