### PR TITLE
Migrate to embedded-hal 1.0.0-alpha5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "HAL for the bl602 microcontroller"
 
 [dependencies]
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
-embedded-hal = "=1.0.0-alpha.4"
+embedded-hal = "=1.0.0-alpha.5"
 embedded-time = "0.12.0"
 riscv = "0.6.0"
 nb = "1.0"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -2,6 +2,8 @@
 #![no_main]
 
 use bl602_hal as hal;
+use embedded_hal::delay::blocking::DelayMs;
+use embedded_hal::digital::blocking::OutputPin;
 use hal::{
     clock::{Strict, SysclkFreq, UART_PLL_FREQ},
     pac,
@@ -27,10 +29,10 @@ fn main() -> ! {
     let mut d = bl602_hal::delay::McycleDelay::new(clocks.sysclk().0);
 
     loop {
-        gpio5.try_set_high().unwrap();
-        d.try_delay_ms(1000).unwrap();
+        gpio5.set_high().unwrap();
+        d.delay_ms(1000).unwrap();
 
-        gpio5.try_set_low().unwrap();
-        d.try_delay_ms(1000).unwrap();
+        gpio5.set_low().unwrap();
+        d.delay_ms(1000).unwrap();
     }
 }

--- a/examples/i2c_ssd1306.rs
+++ b/examples/i2c_ssd1306.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
 
     let scl = parts.pin4.into_i2c_scl();
     let sda = parts.pin5.into_i2c_sda();
-    let i2c = hal::i2c::I2c::i2c(dp.I2C, (scl, sda), 100_000u32.Hz(), clocks);
+    let i2c = hal::i2c::I2c::new(dp.I2C, (scl, sda), 100_000u32.Hz(), clocks);
 
     let interface = I2CDisplayInterface::new(i2c);
     let mut display = Ssd1306::new(interface, DisplaySize128x32, DisplayRotation::Rotate0)

--- a/examples/led_interrupt_switch.rs
+++ b/examples/led_interrupt_switch.rs
@@ -3,6 +3,8 @@
 
 use core::mem::MaybeUninit;
 use bl602_hal as hal;
+use embedded_hal::digital::blocking::StatefulOutputPin;
+use embedded_hal::digital::blocking::OutputPin;
 use hal::{pac, prelude::*, interrupts::*};
 use panic_halt as _;
 
@@ -28,7 +30,7 @@ fn main() -> ! {
     let mut gpio3 = parts.pin3.into_pull_down_input();
     let mut gpio5 = parts.pin5.into_pull_down_output();
 
-    gpio5.try_set_high().unwrap();
+    gpio5.set_high().unwrap();
 
     gpio3.enable_smitter();
     gpio3.trigger_on_event(hal::gpio::Event::NegativePulse);
@@ -59,13 +61,13 @@ fn Gpio(_trap_frame: &mut TrapFrame) {
     get_gpio3().disable_interrupt();
     get_gpio3().clear_interrupt_pending_bit();
 
-    let is_on = get_gpio5().try_is_set_high();
+    let is_on = get_gpio5().is_set_high();
     if let Ok(res) = is_on {
         if res {
-            get_gpio5().try_set_low().unwrap();
+            get_gpio5().set_low().unwrap();
         }
         else {
-            get_gpio5().try_set_high().unwrap();
+            get_gpio5().set_high().unwrap();
         }
     }
 

--- a/examples/led_interrupt_switch.rs
+++ b/examples/led_interrupt_switch.rs
@@ -1,18 +1,19 @@
 #![no_std]
 #![no_main]
 
-use core::mem::MaybeUninit;
 use bl602_hal as hal;
-use embedded_hal::digital::blocking::StatefulOutputPin;
+use core::mem::MaybeUninit;
 use embedded_hal::digital::blocking::OutputPin;
-use hal::{pac, prelude::*, interrupts::*};
+use embedded_hal::digital::blocking::StatefulOutputPin;
+use hal::{interrupts::*, pac, prelude::*};
 use panic_halt as _;
 
 use bl602_hal::gpio::InterruptPin;
 
-
-static mut GPIO3: MaybeUninit<hal::gpio::pin::Pin3<hal::gpio::Input<hal::gpio::PullDown>>> = MaybeUninit::uninit();
-static mut GPIO5: MaybeUninit<hal::gpio::pin::Pin5<hal::gpio::Output<hal::gpio::PullDown>>> = MaybeUninit::uninit();
+static mut GPIO3: MaybeUninit<hal::gpio::pin::Pin3<hal::gpio::Input<hal::gpio::PullDown>>> =
+    MaybeUninit::uninit();
+static mut GPIO5: MaybeUninit<hal::gpio::pin::Pin5<hal::gpio::Output<hal::gpio::PullDown>>> =
+    MaybeUninit::uninit();
 
 fn get_gpio3() -> &'static mut hal::gpio::pin::Pin3<hal::gpio::Input<hal::gpio::PullDown>> {
     unsafe { &mut *GPIO3.as_mut_ptr() }
@@ -65,8 +66,7 @@ fn Gpio(_trap_frame: &mut TrapFrame) {
     if let Ok(res) = is_on {
         if res {
             get_gpio5().set_low().unwrap();
-        }
-        else {
+        } else {
             get_gpio5().set_high().unwrap();
         }
     }

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     );
 
     // Create RTC
-    let rtc = Rtc::rtc(dp.HBN);
+    let rtc = Rtc::new(dp.HBN);
 
     loop {
         write!(

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -3,6 +3,7 @@
 
 use bl602_hal as hal;
 use core::fmt::Write;
+use embedded_hal::delay::blocking::DelayMs;
 use hal::{
     clock::{Strict, SysclkFreq, UART_PLL_FREQ},
     pac,
@@ -43,6 +44,6 @@ fn main() -> ! {
 
     loop {
         serial.write_str("Hello Rust\r\n").ok();
-        d.try_delay_ms(1000).unwrap();
+        d.delay_ms(1000).unwrap();
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -27,7 +27,7 @@ use crate::delay::*;
 use crate::gpio::ClkCfg;
 use crate::pac;
 use core::num::NonZeroU32;
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::blocking::DelayUs;
 use embedded_time::rate::{Extensions, Hertz};
 
 /// Internal high-speed RC oscillator frequency
@@ -367,13 +367,13 @@ fn glb_set_system_clk_div(hclkdiv: u8, bclkdiv: u8) {
     let mut delay = McycleDelay::new(system_core_clock_get());
 
     // This delay used to be 8 NOPS (1/4 us). Might need to be replaced again.
-    delay.try_delay_us(1).unwrap();
+    delay.delay_us(1).unwrap();
 
     unsafe { &*pac::GLB::ptr() }
         .clk_cfg0
         .modify(|_, w| w.reg_hclk_en().set_bit().reg_bclk_en().set_bit());
 
-    delay.try_delay_us(1).unwrap();
+    delay.delay_us(1).unwrap();
 }
 
 // This is a reference implementation of `PDS_Select_XTAL_As_PLL_Ref`.
@@ -532,7 +532,7 @@ fn pds_power_on_pll(freq: u32) {
     pds.pu_rst_clkpll
         .modify(|_, w| w.pu_clkpll_sfreg().set_bit());
 
-    delay.try_delay_us(5).unwrap();
+    delay.delay_us(5).unwrap();
 
     pds.pu_rst_clkpll.modify(|_, w| w.pu_clkpll().set_bit());
 
@@ -547,22 +547,22 @@ fn pds_power_on_pll(freq: u32) {
             .set_bit()
     });
 
-    delay.try_delay_us(5).unwrap();
+    delay.delay_us(5).unwrap();
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_sdm_reset().set_bit());
 
-    delay.try_delay_us(1).unwrap();
+    delay.delay_us(1).unwrap();
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_reset_fbdv().set_bit());
 
-    delay.try_delay_us(2).unwrap();
+    delay.delay_us(2).unwrap();
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_reset_fbdv().clear_bit());
 
-    delay.try_delay_us(1).unwrap();
+    delay.delay_us(1).unwrap();
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_sdm_reset().clear_bit());
@@ -576,7 +576,7 @@ fn aon_power_on_xtal() -> Result<(), &'static str> {
     let mut delaysrc = McycleDelay::new(system_core_clock_get());
     let mut timeout: u32 = 0;
 
-    delaysrc.try_delay_us(10).unwrap();
+    delaysrc.delay_us(10).unwrap();
 
     while unsafe { &*pac::AON::ptr() }
         .tsen
@@ -585,7 +585,7 @@ fn aon_power_on_xtal() -> Result<(), &'static str> {
         .bit_is_clear()
         && timeout < 120
     {
-        delaysrc.try_delay_us(10).unwrap();
+        delaysrc.delay_us(10).unwrap();
         timeout += 1;
     }
 
@@ -653,7 +653,7 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     pds_power_on_pll_rom(xtal_freq);
 
     let mut delay = McycleDelay::new(system_core_clock_get());
-    delay.try_delay_us(55).unwrap();
+    delay.delay_us(55).unwrap();
 
     pds_enable_pll_all_clks();
 
@@ -695,7 +695,7 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     let mut delay = McycleDelay::new(system_core_clock_get());
 
     // This delay used to be 8 NOPS (1/4 us). (GLB_CLK_SET_DUMMY_WAIT) Might need to be replaced again.
-    delay.try_delay_us(1).unwrap();
+    delay.delay_us(1).unwrap();
 
     // use 120Mhz PLL tap for PKA clock since we're using PLL
     // NOTE: This isn't documented in the datasheet!

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,7 +1,7 @@
 //! Delays
 
 use core::convert::Infallible;
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::delay::blocking::{DelayMs, DelayUs};
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
 ///
@@ -48,7 +48,7 @@ impl DelayUs<u64> for McycleDelay {
 
     /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
-    fn try_delay_us(&mut self, us: u64) -> Result<(), Infallible> {
+    fn delay_us(&mut self, us: u64) -> Result<(), Infallible> {
         McycleDelay::delay_cycles((us * (self.core_frequency as u64)) / 1_000_000);
 
         Ok(())
@@ -60,7 +60,7 @@ impl DelayMs<u64> for McycleDelay {
 
     /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]
-    fn try_delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
+    fn delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
         McycleDelay::delay_cycles((ms * (self.core_frequency as u64)) / 1000);
 
         Ok(())

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -502,7 +502,17 @@ macro_rules! impl_glb {
                 }
             }
 
-            impl<MODE> ToggleableOutputPin for $Pini<Output<MODE>> {}
+            impl<MODE> ToggleableOutputPin for $Pini<Output<MODE>> {
+                type Error = Infallible;
+                fn toggle(&mut self) -> Result<(), Self::Error> {
+                    // infallible, so unwrap_or will never be processed
+                    if self.is_set_high().unwrap_or(false) {
+                        self.set_low()
+                    } else {
+                        self.set_high()
+                    }
+                }
+            }
             )+
         }
     };

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -280,7 +280,7 @@ macro_rules! impl_glb {
         pub mod pin {
             use core::marker::PhantomData;
             use core::convert::Infallible;
-            use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin, toggleable};
+            use embedded_hal::digital::blocking::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
             use crate::pac;
             use super::*;
@@ -391,13 +391,13 @@ macro_rules! impl_glb {
                 type Error = Infallible;
 
                 paste::paste! {
-                    fn try_is_high(&self) -> Result<bool, Self::Error> {
+                    fn is_high(&self) -> Result<bool, Self::Error> {
                         let glb = unsafe { &*pac::GLB::ptr() };
 
                         Ok(glb.gpio_cfgctl30.read().[<reg_ $gpio_i _i>]().bit_is_set())
                     }
 
-                    fn try_is_low(&self) -> Result<bool, Self::Error> {
+                    fn is_low(&self) -> Result<bool, Self::Error> {
                         let glb = unsafe { &*pac::GLB::ptr() };
 
                         Ok(glb.gpio_cfgctl30.read().[<reg_ $gpio_i _i>]().bit_is_clear())
@@ -468,7 +468,7 @@ macro_rules! impl_glb {
                 type Error = Infallible;
 
                 paste::paste! {
-                    fn try_set_high(&mut self) -> Result<(), Self::Error> {
+                    fn set_high(&mut self) -> Result<(), Self::Error> {
                         let glb = unsafe { &*pac::GLB::ptr() };
 
                         glb.gpio_cfgctl32.modify(|_, w| w.[<reg_ $gpio_i _o>]().set_bit());
@@ -476,7 +476,7 @@ macro_rules! impl_glb {
                         Ok(())
                     }
 
-                    fn try_set_low(&mut self) -> Result<(), Self::Error> {
+                    fn set_low(&mut self) -> Result<(), Self::Error> {
                         let glb = unsafe { &*pac::GLB::ptr() };
 
                         glb.gpio_cfgctl32.modify(|_, w| w.[<reg_ $gpio_i _o>]().clear_bit());
@@ -488,13 +488,13 @@ macro_rules! impl_glb {
 
             impl<MODE> StatefulOutputPin for $Pini<Output<MODE>> {
                 paste::paste! {
-                    fn try_is_set_high(&self) -> Result<bool, Self::Error> {
+                    fn is_set_high(&self) -> Result<bool, Self::Error> {
                         let glb = unsafe { &*pac::GLB::ptr() };
 
                         Ok(glb.gpio_cfgctl32.read().[<reg_ $gpio_i _o>]().bit_is_set())
                     }
 
-                    fn try_is_set_low(&self) -> Result<bool, Self::Error> {
+                    fn is_set_low(&self) -> Result<bool, Self::Error> {
                         let glb = unsafe { &*pac::GLB::ptr() };
 
                         Ok(glb.gpio_cfgctl32.read().[<reg_ $gpio_i _o>]().bit_is_clear())
@@ -502,7 +502,7 @@ macro_rules! impl_glb {
                 }
             }
 
-            impl<MODE> toggleable::Default for $Pini<Output<MODE>> {}
+            impl<MODE> ToggleableOutputPin for $Pini<Output<MODE>> {}
             )+
         }
     };

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -22,11 +22,11 @@ use embedded_hal::i2c::SevenBitAddress;
 // use embedded_hal::blocking;
 // use embedded_hal::prelude::_embedded_hal_blocking_i2c_Read;
 // use embedded_hal::prelude::_embedded_hal_blocking_i2c_Write;
-use embedded_hal_zero::blocking::i2c::Read as ReadZero;
-use embedded_hal_zero::blocking::i2c::Write as WriteZero;
 use embedded_hal::i2c as i2cAlpha;
 use embedded_hal::i2c::blocking::Read as ReadAlpha;
 use embedded_hal::i2c::blocking::Write as WriteAlpha;
+use embedded_hal_zero::blocking::i2c::Read as ReadZero;
+use embedded_hal_zero::blocking::i2c::Write as WriteZero;
 // use embedded_hal::i2c::blocking;
 use embedded_time::rate::Hertz;
 
@@ -343,6 +343,6 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        WriteAlpha::write(self,addr, bytes)
+        WriteAlpha::write(self, addr, bytes)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -18,11 +18,14 @@
 */
 
 use bl602_pac::I2C;
-use embedded_hal::blocking;
-use embedded_hal::prelude::_embedded_hal_blocking_i2c_Read;
-use embedded_hal::prelude::_embedded_hal_blocking_i2c_Write;
+use embedded_hal::i2c::SevenBitAddress;
+// use embedded_hal::blocking;
+// use embedded_hal::prelude::_embedded_hal_blocking_i2c_Read;
+// use embedded_hal::prelude::_embedded_hal_blocking_i2c_Write;
 use embedded_hal_zero::blocking::i2c::Read as ReadZero;
 use embedded_hal_zero::blocking::i2c::Write as WriteZero;
+use embedded_hal::i2c;
+use embedded_hal::i2c::blocking;
 use embedded_time::rate::Hertz;
 
 use crate::{clock::Clocks, pac};
@@ -175,15 +178,15 @@ where
     }
 }
 
-impl<PINS> blocking::i2c::Read<blocking::i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
+impl<PINS> i2c::blocking::Read<i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
 where
     PINS: Pins<pac::I2C>,
 {
     type Error = Error;
 
-    fn try_read(
+    fn read(
         &mut self,
-        address: blocking::i2c::SevenBitAddress,
+        address: i2c::SevenBitAddress,
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         let fifo_config = self.i2c.i2c_fifo_config_0.read();
@@ -245,15 +248,15 @@ where
     }
 }
 
-impl<PINS> blocking::i2c::Write<blocking::i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
+impl<PINS> i2c::blocking::Write<i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
 where
     PINS: Pins<pac::I2C>,
 {
     type Error = Error;
 
-    fn try_write(
+    fn write(
         &mut self,
-        address: blocking::i2c::SevenBitAddress,
+        address: i2c::SevenBitAddress,
         buffer: &[u8],
     ) -> Result<(), Self::Error> {
         let fifo_config = self.i2c.i2c_fifo_config_0.read();
@@ -327,7 +330,7 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.try_read(address, buffer)
+        self.read(address, buffer)
     }
 }
 
@@ -338,6 +341,6 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.try_write(addr, bytes)
+        self.write(addr, bytes)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -101,7 +101,7 @@ where
 
       The I2C instance supports 7 bit addressing mode.
     */
-    pub fn i2c(i2c: I2C, pins: PINS, freq: Hertz<u32>, clocks: Clocks) -> Self
+    pub fn new(i2c: I2C, pins: PINS, freq: Hertz<u32>, clocks: Clocks) -> Self
     where
         PINS: Pins<pac::I2C>,
     {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,6 @@
 /*!
   # Inter-Integrated Circuit (I2C) bus
-  To construct the I2C instance use the `I2c::i2c` function.
+  To construct the I2C instance use the `I2c::new` function.
   The pin parameter is a tuple containing `(scl, sda)` which should be configured via `into_i2c_scl` and `into_i2c_sda`.
 
   ## Initialisation example

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -24,8 +24,10 @@ use embedded_hal::i2c::SevenBitAddress;
 // use embedded_hal::prelude::_embedded_hal_blocking_i2c_Write;
 use embedded_hal_zero::blocking::i2c::Read as ReadZero;
 use embedded_hal_zero::blocking::i2c::Write as WriteZero;
-use embedded_hal::i2c;
-use embedded_hal::i2c::blocking;
+use embedded_hal::i2c as i2cAlpha;
+use embedded_hal::i2c::blocking::Read as ReadAlpha;
+use embedded_hal::i2c::blocking::Write as WriteAlpha;
+// use embedded_hal::i2c::blocking;
 use embedded_time::rate::Hertz;
 
 use crate::{clock::Clocks, pac};
@@ -178,7 +180,7 @@ where
     }
 }
 
-impl<PINS> i2c::blocking::Read<i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
+impl<PINS> ReadAlpha<i2cAlpha::SevenBitAddress> for I2c<pac::I2C, PINS>
 where
     PINS: Pins<pac::I2C>,
 {
@@ -186,7 +188,7 @@ where
 
     fn read(
         &mut self,
-        address: i2c::SevenBitAddress,
+        address: i2cAlpha::SevenBitAddress,
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         let fifo_config = self.i2c.i2c_fifo_config_0.read();
@@ -248,7 +250,7 @@ where
     }
 }
 
-impl<PINS> i2c::blocking::Write<i2c::SevenBitAddress> for I2c<pac::I2C, PINS>
+impl<PINS> WriteAlpha<i2cAlpha::SevenBitAddress> for I2c<pac::I2C, PINS>
 where
     PINS: Pins<pac::I2C>,
 {
@@ -256,7 +258,7 @@ where
 
     fn write(
         &mut self,
-        address: i2c::SevenBitAddress,
+        address: i2cAlpha::SevenBitAddress,
         buffer: &[u8],
     ) -> Result<(), Self::Error> {
         let fifo_config = self.i2c.i2c_fifo_config_0.read();
@@ -330,7 +332,7 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        self.read(address, buffer)
+        ReadAlpha::read(self, address, buffer)
     }
 }
 
@@ -341,6 +343,6 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.write(addr, bytes)
+        WriteAlpha::write(self,addr, bytes)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -18,16 +18,11 @@
 */
 
 use bl602_pac::I2C;
-use embedded_hal::i2c::SevenBitAddress;
-// use embedded_hal::blocking;
-// use embedded_hal::prelude::_embedded_hal_blocking_i2c_Read;
-// use embedded_hal::prelude::_embedded_hal_blocking_i2c_Write;
 use embedded_hal::i2c as i2cAlpha;
 use embedded_hal::i2c::blocking::Read as ReadAlpha;
 use embedded_hal::i2c::blocking::Write as WriteAlpha;
 use embedded_hal_zero::blocking::i2c::Read as ReadZero;
 use embedded_hal_zero::blocking::i2c::Write as WriteZero;
-// use embedded_hal::i2c::blocking;
 use embedded_time::rate::Hertz;
 
 use crate::{clock::Clocks, pac};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,5 @@ pub mod timer;
 /// HAL crate prelude
 pub mod prelude {
     pub use crate::gpio::GlbExt as _bl602_hal_gpio_GlbExt;
-    pub use embedded_hal::prelude::*;
     pub use embedded_time::rate::Extensions;
 }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -4,7 +4,7 @@
 
   ## Initialisation example
   ```rust
-    let rtc = Rtc::rtc(dp.HBN);
+    let rtc = Rtc::new(dp.HBN);
   ```
 */
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -17,7 +17,7 @@ pub struct Rtc {
 
 impl Rtc {
     /// Creates and starts the RTC
-    pub fn rtc(hbn: HBN) -> Rtc {
+    pub fn new(hbn: HBN) -> Rtc {
         // clear counter
         hbn.hbn_ctl
             .modify(|r, w| unsafe { w.rtc_ctl().bits(r.rtc_ctl().bits() & 0xfe) });

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -251,10 +251,10 @@ where
     }
 }
 
-impl<PINS> embedded_hal::serial::Write<u8> for Serial<pac::UART, PINS> {
+impl<PINS> embedded_hal::serial::nb::Write<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
-    fn try_write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         // If there's no room to write a byte or more to the FIFO, return WouldBlock
         if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() == 0 {
             Err(nb::Error::WouldBlock)
@@ -266,7 +266,7 @@ impl<PINS> embedded_hal::serial::Write<u8> for Serial<pac::UART, PINS> {
         }
     }
 
-    fn try_flush(&mut self) -> nb::Result<(), Self::Error> {
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
         // If we're still transmitting or have data in our 32 byte FIFO, return WouldBlock
         if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() != 32
             || self.uart.uart_status.read().sts_utx_bus_busy().bit_is_set()
@@ -278,10 +278,10 @@ impl<PINS> embedded_hal::serial::Write<u8> for Serial<pac::UART, PINS> {
     }
 }
 
-impl<PINS> embedded_hal::serial::Read<u8> for Serial<pac::UART, PINS> {
+impl<PINS> embedded_hal::serial::nb::Read<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
-    fn try_read(&mut self) -> nb::Result<u8, Self::Error> {
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
         let ans = self.uart.uart_fifo_rdata.read().bits();
 
         Ok((ans & 0xff) as u8)
@@ -290,7 +290,7 @@ impl<PINS> embedded_hal::serial::Read<u8> for Serial<pac::UART, PINS> {
 
 impl<UART, PINS> fmt::Write for Serial<UART, PINS>
 where
-    Serial<UART, PINS>: embedded_hal::serial::Write<u8>,
+    Serial<UART, PINS>: embedded_hal::serial::nb::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         s.as_bytes()

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -2,7 +2,7 @@
 use crate::clock::Clocks;
 use crate::pac;
 use core::fmt;
-use embedded_hal::prelude::_embedded_hal_serial_Write;
+use embedded_hal::serial::nb::Write;
 use embedded_time::rate::{Baud, Extensions};
 use nb::block;
 
@@ -295,7 +295,7 @@ where
     fn write_str(&mut self, s: &str) -> fmt::Result {
         s.as_bytes()
             .iter()
-            .try_for_each(|c| block!(self.try_write(*c)))
+            .try_for_each(|c| block!(self.write(*c)))
             .map_err(|_| fmt::Error)
     }
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -23,8 +23,8 @@
 
 use bl602_pac::SPI;
 pub use embedded_hal::spi::blocking::Transfer;
-pub use embedded_hal::spi::Mode;
 use embedded_hal::spi::nb::FullDuplex;
+pub use embedded_hal::spi::Mode;
 use embedded_time::rate::Hertz;
 
 use crate::pac;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,6 +1,6 @@
 /*!
   # Serial Peripheral Interface
-  To construct the SPI instances, use the `Spi::spi` function.
+  To construct the SPI instances, use the `Spi::new` function.
   The pin parameter is a tuple containing `(miso, mosi, cs, sck)` which should be configured via `into_spi_miso, into_spi_mosi, into_spi_ss, into_spi_sclk`.
 
   CS is optional - so you can also pass a tuple containing `(miso, mosi, sck)`
@@ -11,7 +11,7 @@
     let ss = parts.pin2.into_spi_ss();
     let sclk = parts.pin3.into_spi_sclk();
 
-    let mut spi = hal::spi::Spi::spi(
+    let mut spi = hal::spi::Spi::new(
         dp.SPI,
         (miso, mosi, ss, sclk),
         embedded_hal::spi::MODE_0,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -127,7 +127,7 @@ where
 
       The frequency cannot be more than half of the spi clock frequency.
     */
-    pub fn spi(spi: SPI, pins: PINS, mode: Mode, freq: Hertz<u32>, clocks: Clocks) -> Self
+    pub fn new(spi: SPI, pins: PINS, mode: Mode, freq: Hertz<u32>, clocks: Clocks) -> Self
     where
         PINS: Pins<pac::SPI>,
     {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -22,7 +22,9 @@
 */
 
 use bl602_pac::SPI;
-pub use embedded_hal::spi::{FullDuplex, Mode};
+pub use embedded_hal::spi::blocking::Transfer;
+pub use embedded_hal::spi::Mode;
+use embedded_hal::spi::nb::FullDuplex;
 use embedded_time::rate::Hertz;
 
 use crate::pac;
@@ -216,7 +218,7 @@ where
 {
     type Error = Error;
 
-    fn try_read(&mut self) -> nb::Result<u8, Error> {
+    fn read(&mut self) -> nb::Result<u8, Error> {
         let spi_fifo_config_0 = self.spi.spi_fifo_config_0.read();
 
         if spi_fifo_config_0.rx_fifo_overflow().bit_is_set() {
@@ -230,7 +232,7 @@ where
         }
     }
 
-    fn try_send(&mut self, data: u8) -> nb::Result<(), Self::Error> {
+    fn write(&mut self, data: u8) -> nb::Result<(), Self::Error> {
         let spi_fifo_config_0 = self.spi.spi_fifo_config_0.read();
 
         if spi_fifo_config_0.tx_fifo_overflow().bit_is_set() {
@@ -249,22 +251,23 @@ where
     }
 }
 
-impl<PINS> embedded_hal::blocking::spi::transfer::Default<u8> for Spi<pac::SPI, PINS> where
-    PINS: Pins<pac::SPI>
-{
-}
+//TODO: Default marker traits are removed, must re-implement manually
+// impl<PINS> embedded_hal::blocking::spi::transfer::Default<u8> for Spi<pac::SPI, PINS> where
+//     PINS: Pins<pac::SPI>
+// {
+// }
 
-impl<PINS> embedded_hal::blocking::spi::write::Default<u8> for Spi<pac::SPI, PINS> where
-    PINS: Pins<pac::SPI>
-{
-}
+// impl<PINS> embedded_hal::blocking::spi::write::Default<u8> for Spi<pac::SPI, PINS> where
+//     PINS: Pins<pac::SPI>
+// {
+// }
 
-impl<PINS> embedded_hal::blocking::spi::write_iter::Default<u8> for Spi<pac::SPI, PINS> where
-    PINS: Pins<pac::SPI>
-{
-}
+// impl<PINS> embedded_hal::blocking::spi::write_iter::Default<u8> for Spi<pac::SPI, PINS> where
+//     PINS: Pins<pac::SPI>
+// {
+// }
 
-impl<PINS> embedded_hal::blocking::spi::transactional::Default<u8> for Spi<pac::SPI, PINS> where
-    PINS: Pins<pac::SPI>
-{
-}
+// impl<PINS> embedded_hal::blocking::spi::transactional::Default<u8> for Spi<pac::SPI, PINS> where
+//     PINS: Pins<pac::SPI>
+// {
+// }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -277,12 +277,12 @@ macro_rules! impl_timer_channel {
             }
         }
 
-        impl embedded_hal::timer::CountDown for $conf_name {
+        impl embedded_hal::timer::nb::CountDown for $conf_name {
             type Error = CountDownError;
 
             type Time = Milliseconds;
 
-            fn try_start<T>(&mut self, count: T) -> Result<(), Self::Error>
+            fn start<T>(&mut self, count: T) -> Result<(), Self::Error>
             where
                 T: Into<Self::Time>,
             {
@@ -291,7 +291,7 @@ macro_rules! impl_timer_channel {
                 Ok(())
             }
 
-            fn try_wait(&mut self) -> nb::Result<(), Self::Error> {
+            fn wait(&mut self) -> nb::Result<(), Self::Error> {
                 match self.count_down_target {
                     Some(millis) => {
                         let current_time = self.current_time();


### PR DESCRIPTION
Lots of little changes to bring us over to alpha5.
The biggest change is the lack of Default impls for some traits in SPI.
I implemented the GPIO toggle trait manually, as I figure that's going to be commonly used.

I also renamed the i2c, rtc and spi constructors to be called new() because clippy complained and calling hal::i2c::I2c::i2c() feels pretty silly. That was the last change, and I can back it out if it is too much.