### PR TITLE
Implement embedded-hal 0.2 GPIO traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ paste = "1.0"
 [dependencies.embedded-hal-zero]
 version = "0.2.5"
 package = "embedded-hal"
+features = ["unproven"]
 
 [dev-dependencies]
 riscv-rt = "0.8.0"


### PR DESCRIPTION
Since we have an e-h 0.2 implementation for i2c I thought it would be nice to have one for GPIO as well.
I moved the actual implementations behind some internal traits to avoid name resolution issues, but I think they make it slightly cleaner anyway due to not needing to handle a Result() everywhere.