### PR TITLE
Implement embedded-hal 0.2 SPI traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ paste = "1.0"
 [dependencies.embedded-hal-zero]
 version = "0.2.5"
 package = "embedded-hal"
+features = ["unproven"]
 
 [dev-dependencies]
 riscv-rt = "0.8.0"


### PR DESCRIPTION
Implementing the 0.2 SPI traits was easier because I could fall back on the defaults impls.
I also brought back a few of the 1.0 impls, though they're basically just copies of the default impls anyway.