### PR TITLE
Implement embedded-hal 0.2 UART traits + fix read

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -283,9 +283,13 @@ impl<PINS> embedded_hal::serial::nb::Read<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        let ans = self.uart.uart_fifo_rdata.read().bits();
-
-        Ok((ans & 0xff) as u8)
+        if self.uart.uart_fifo_config_1.read().rx_fifo_cnt().bits() == 0 {
+            Err(nb::Error::WouldBlock)
+        }
+        else {
+            let ans = self.uart.uart_fifo_rdata.read().bits();
+            Ok((ans & 0xff) as u8)
+        }
     }
 }
 


### PR DESCRIPTION
Implemented e-h 0.2 read() and write() by calling 1.0 read() and write().

Also check the UART FIFO has any data in it before reading.
Before this change it would just keep returning the last received character over and over again.
Now it returns nb::Error::WouldBlock like you would expect.