### PR TITLE
Allow generic time units in timer setup functions

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -14,10 +14,10 @@
     ch0.enable_match1_interrupt();
     ch0.disable_match2_interrupt();
 
-    ch0.set_preload_value(Milliseconds::new(0));
+    ch0.set_preload_value(0.milliseconds());
     ch0.set_preload(hal::timer::Preload::PreloadMatchComparator1);
-    ch0.set_match0(Milliseconds::new(3_000u32));
-    ch0.set_match1(Milliseconds::new(7_000u32));
+    ch0.set_match0(3_u32.seconds());
+    ch0.set_match1(7_000_000_000_u32.microseconds());
 
     ch0.enable(); // start timer
   ```
@@ -27,8 +27,8 @@ use crate::{clock::Clocks, pac};
 use bl602_pac::TIMER;
 use core::cell::RefCell;
 use embedded_time::{
-    duration::Milliseconds,
-    rate::{Extensions, Hertz},
+    duration::*,
+    rate::*,
 };
 use paste::paste;
 
@@ -205,22 +205,25 @@ macro_rules! impl_timer_channel {
                 }
 
                 /// Sets match register 0
-                pub fn set_match0(&self, time: Milliseconds) {
-                    let time = (self.clock.0 as u64 * time.0 as u64 / 1_000u64) as u32;
+                pub fn set_match0(&self, time: impl Into<Nanoseconds::<u64>>) {
+                    let time: Nanoseconds::<u64> = time.into();
+                    let time = (self.clock.0 as u64 * time.integer() / 1_000_000_000_u64) as u32;
                     let timer = unsafe { &*pac::TIMER::ptr() };
                     timer.[<tmr $channel _0>].modify(|_r, w| unsafe { w.tmr().bits(time) });
                 }
 
                 /// Sets match register 1
-                pub fn set_match1(&self, time: Milliseconds) {
-                    let time = (self.clock.0 as u64 * time.0 as u64 / 1_000u64) as u32;
+                pub fn set_match1(&self, time: impl Into<Nanoseconds::<u64>>) {
+                    let time: Nanoseconds::<u64> = time.into();
+                    let time = (self.clock.0 as u64 * time.integer() / 1_000_000_000_u64) as u32;
                     let timer = unsafe { &*pac::TIMER::ptr() };
                     timer.[<tmr $channel _1>].modify(|_r, w| unsafe { w.tmr().bits(time) });
                 }
 
                 /// Sets match register 2
-                pub fn set_match2(&self, time: Milliseconds) {
-                    let time = (self.clock.0 as u64 * time.0 as u64 / 1_000u64) as u32;
+                pub fn set_match2(&self, time: impl Into<Nanoseconds::<u64>>) {
+                    let time: Nanoseconds::<u64> = time.into();
+                    let time = (self.clock.0 as u64 * time.integer() / 1_000_000_000_u64) as u32;
                     let timer = unsafe { &*pac::TIMER::ptr() };
                     timer.[<tmr $channel _2>].modify(|_r, w| unsafe { w.tmr().bits(time) });
                 }
@@ -269,8 +272,9 @@ macro_rules! impl_timer_channel {
                 }
 
                 /// The value which should be used for preload.
-                pub fn set_preload_value(&self, time: Milliseconds) {
-                    let time = (self.clock.0 as u64 * time.0 as u64 / 1_000u64) as u32;
+                pub fn set_preload_value(&self, time: impl Into<Nanoseconds::<u64>>) {
+                    let time: Nanoseconds::<u64> = time.into();
+                    let time = (self.clock.0 as u64 * time.0 / 1_000_000_000_u64) as u32;
                     let timer = unsafe { &*pac::TIMER::ptr() };
                     timer.[<tplvr $channel>].modify(|_r, w| unsafe { w.bits(time) });
                 }
@@ -327,8 +331,9 @@ macro_rules! impl_timer_channel {
                 pub fn set_clock_source(
                     self,
                     source: ClockSource,
-                    target_clock: Hertz,
+                    desired_timing: impl Into<Hertz>,
                 ) -> $conf_name {
+                    let target_clock: Hertz = desired_timing.into();
                     let timer = unsafe { &*pac::TIMER::ptr() };
                     timer
                         .tccr


### PR DESCRIPTION
 -This implements the ability for any embedded-time::duration::* or embedded-time::rate::* to be used where previously only Hertz or Milliseconds were accepted.

This should resolve issue https://github.com/sipeed/bl602-hal/issues/36