### PR TITLE
Version update riscv to support hard floats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "HAL for the bl602 microcontroller"
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
 embedded-hal = "=1.0.0-alpha.5"
 embedded-time = "0.12.0"
-riscv = "0.6.0"
+riscv = "0.7.0"
 nb = "1.0"
 paste = "1.0"
 


### PR DESCRIPTION
This is the follow up to the ```bl602-pac``` update to allow hard floats by updating to ```riscv 0.7.0```. I have left the riscv-rt version at 0.8.0 as suggested by @9names; letting semver take care of finding the newest release now that it is published.