### PR TITLE
Bump riscv-rt to v0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ package = "embedded-hal"
 features = ["unproven"]
 
 [dev-dependencies]
-riscv-rt = "0.8.0"
+riscv-rt = "0.11.0"
 panic-halt = "0.2.0"
 ssd1306 = "0.6.0"
 embedded-graphics = "0.7.1"


### PR DESCRIPTION
Only affects example builds. Previous versions encounter a lld error fixed in more recent stable. Skip v0.10 as has been yanked.

Fixes #41 