### PR TITLE
Use critical-section instead of bare-metal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
         include:
           # Run check with MSRV as well
-          - rust: 1.42.0
+          - rust: 1.59.0
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "HAL for the bl602 microcontroller"
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
 embedded-hal = "=1.0.0-alpha.5"
 embedded-time = "0.12.0"
-riscv = "0.7.0"
+riscv = { version = "0.10.1", features = ["critical-section-single-hart"] }
 nb = "1.0"
 paste = "1.0"
 
@@ -27,6 +27,7 @@ riscv-rt = "0.11.0"
 panic-halt = "0.2.0"
 ssd1306 = "0.6.0"
 embedded-graphics = "0.7.1"
+critical-section = "1.1"
 
 [build-dependencies]
 riscv-target = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ package = "embedded-hal"
 features = ["unproven"]
 
 [dev-dependencies]
-riscv-rt = "0.8.0"
+riscv-rt = "0.11.0"
 panic-halt = "0.2.0"
 ssd1306 = "0.6.0"
 embedded-graphics = "0.7.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Matrix: [#bl602-rust:matrix.org](https://matrix.to/#/#bl602-rust:matrix.org)
 
 ## Minimum Supported Rust Version
 
-The minimum supported Rust version (MSRV) for this project is Rust **v1.42.0**. The
+The minimum supported Rust version (MSRV) for this project is Rust **v1.59.0**. The
 project might build on earlier versions, but this is the earliest version that
 is expected to work.
 


### PR DESCRIPTION
Uses `riscv`'s `critical-section` impl.
We need this it use newer versions of svd2rust anyway.
The examples weren't building for me without it.

Merge #42 first 