### PR TITLE
Updates for new PAC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "HAL for the bl602 microcontroller"
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
 embedded-hal = "=1.0.0-alpha.5"
 embedded-time = "0.12.0"
-riscv = { version = "0.10.1", features = ["critical-section-single-hart"] }
+riscv = "0.10.1"
 nb = "1.0"
 paste = "1.0"
 
@@ -31,3 +31,7 @@ critical-section = "1.1"
 
 [build-dependencies]
 riscv-target = "0.1.2"
+
+[features]
+default = ["critical-section-impl"]
+critical-section-impl = ["bl602-pac/critical-section", "riscv/critical-section-single-hart"]

--- a/build.rs
+++ b/build.rs
@@ -18,12 +18,12 @@ fn main() {
         let target = target.to_string();
 
         fs::copy(
-            format!("bin/trap_{}.a", target),
-            out_dir.join(format!("lib{}.a", name)),
+            format!("bin/trap_{target}.a"),
+            out_dir.join(format!("lib{name}.a")),
         )
         .unwrap();
 
-        println!("cargo:rustc-link-lib=static={}", name);
+        println!("cargo:rustc-link-lib=static={name}");
         println!("cargo:rustc-link-search={}", out_dir.display());
 
         // Put the linker script somewhere the linker can find it

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -33,8 +33,8 @@ fn main() -> ! {
     let mux7 = parts.uart_mux7.into_uart0_rx();
 
     // Configure our UART to 115200Baud, and use the pins we configured above
-    let mut serial = Serial::uart0(
-        dp.UART,
+    let mut serial = Serial::new(
+        dp.UART0,
         Config::default().baudrate(115_200.Bd()),
         ((pin16, mux0), (pin7, mux7)),
         clocks,

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -32,8 +32,8 @@ fn main() -> ! {
     let mux7 = parts.uart_mux7.into_uart0_rx();
 
     // Configure our UART to 115200Baud, and use the pins we configured above
-    let mut serial = Serial::uart0(
-        dp.UART,
+    let mut serial = Serial::new(
+        dp.UART0,
         Config::default().baudrate(115_200.Bd()),
         ((pin16, mux0), (pin7, mux7)),
         clocks,

--- a/examples/watchdog_example.rs
+++ b/examples/watchdog_example.rs
@@ -70,8 +70,8 @@ fn main() -> ! {
     let mux7 = gpio_pins.uart_mux7.into_uart0_rx();
 
     // Configure our UART to 2MBaud, and use the pins we configured above
-    let mut serial = Serial::uart0(
-        dp.UART,
+    let mut serial = Serial::new(
+        dp.UART0,
         Config::default().baudrate(2_000_000.Bd()),
         ((pin16, mux0), (pin7, mux7)),
         clocks,

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -207,7 +207,7 @@ impl Strict {
         let uart_clk = self
             .target_uart_clk
             .map(|f| f.get())
-            .unwrap_or(uart_clk_src as u32);
+            .unwrap_or(uart_clk_src);
 
         let uart_clk_div = {
             let ans = uart_clk_src / uart_clk;
@@ -599,7 +599,7 @@ fn aon_power_on_xtal() -> Result<(), &'static str> {
 fn hbn_set_root_clk_sel_pll() {
     unsafe { &*pac::HBN::ptr() }.hbn_glb.modify(|r, w| unsafe {
         w.hbn_root_clk_sel()
-            .bits(r.hbn_root_clk_sel().bits() as u8 | 0b10u8)
+            .bits(r.hbn_root_clk_sel().bits() | 0b10u8)
     });
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -305,7 +305,7 @@ where
             }
             self.i2c
                 .i2c_fifo_wdata
-                .write(|w| unsafe { w.i2c_fifo_wdata().bits(*value as u32) });
+                .write(|w| unsafe { w.i2c_fifo_wdata().bits(*value) });
         }
 
         while self.i2c.i2c_bus_busy.read().sts_i2c_bus_busy().bit_is_set() {

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -164,7 +164,7 @@ impl ConfiguredWatchdog0 {
     /// Check the value of the watchdog reset register (WTS) to see if a reset has occurred
     pub fn has_watchdog_reset_occurred(&self) -> bool {
         let timer = unsafe { &*pac::TIMER::ptr() };
-        timer.wsr.read().wts().bits() as bool
+        timer.wsr.read().wts().bit_is_set()
     }
 
     /// Clear the watchdog reset register (WTS)

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -184,7 +184,7 @@ impl ConfiguredWatchdog0 {
     /// Gets the value in ticks the match register is currently set to
     pub fn get_match_ticks(&self) -> u16 {
         let timer = unsafe { &*pac::TIMER::ptr() };
-        timer.wmr.read().wmr().bits() as u16
+        timer.wmr.read().wmr().bits()
     }
 
     /// Get the current value of the watchdog timer in nanoseconds
@@ -197,7 +197,7 @@ impl ConfiguredWatchdog0 {
     /// Get the current value in ticks of the watchdog timer
     pub fn get_current_ticks(&self) -> u16 {
         let timer = unsafe { &*pac::TIMER::ptr() };
-        timer.wvr.read().wvr().bits() as u16
+        timer.wvr.read().wvr().bits()
     }
 
     /// Get the current value of the watchdog timer in nanoseconds
@@ -210,7 +210,7 @@ impl ConfiguredWatchdog0 {
     /// Read the TCCR register containing the CS_WDT bits that select the clock source
     pub fn get_cs_wdt(&self) -> u8 {
         let timer = unsafe { &*pac::TIMER::ptr() };
-        timer.tccr.read().cs_wdt().bits() as u8
+        timer.tccr.read().cs_wdt().bits()
     }
 
     /// Read the WMER register's WRIE bit to see if the WDT is in Reset or Interrupt mode.


### PR DESCRIPTION
This PR makes the changes required by the PAC updates in sipeed/bl602-pac#15 and sipeed/bl602-pac#16.

The `serial` module can new be used with both `UART0` and `UART1` by making the UART generic
with bound `Deref<Target = pac::uart0::RegisterBlock>`.

Additionally, I felt like it might be better practice to not unconditionally enable the `critical-section-single-hart` feature of the `riscv` crate, so I create a new feature for this crate to enable it + made it a default feature.

Any suggestions for improvements are welcome.