### PR TITLE
Update embedded-hal traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "HAL for the bl602 microcontroller"
 
 [dependencies]
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
-embedded-hal = "=1.0.0-alpha.5"
+embedded-hal = "=1.0.0-alpha.11"
 embedded-time = "0.12.0"
 riscv = "0.10.1"
 nb = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ description = "HAL for the bl602 microcontroller"
 
 [dependencies]
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
-embedded-hal = "=1.0.0-alpha.11"
-embedded-hal-nb = "=1.0.0-alpha.3"
+embedded-hal = "=1.0.0-rc.1"
+embedded-hal-nb = "=1.0.0-rc.1"
 embedded-time = "0.12.0"
 riscv = "0.10.1"
 nb = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "HAL for the bl602 microcontroller"
 [dependencies]
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
 embedded-hal = "=1.0.0-alpha.11"
+embedded-hal-nb = "=1.0.0-alpha.3"
 embedded-time = "0.12.0"
 riscv = "0.10.1"
 nb = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ embedded-time = "0.12.0"
 riscv = "0.10.1"
 nb = "1.0"
 paste = "1.0"
+void = { default-features = false, version = "1.0.2" }
 
 [dependencies.embedded-hal-zero]
 version = "0.2.5"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -2,8 +2,8 @@
 #![no_main]
 
 use bl602_hal as hal;
-use embedded_hal::delay::blocking::DelayMs;
-use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal::delay::DelayUs;
+use embedded_hal::digital::OutputPin;
 use hal::{
     clock::{Strict, SysclkFreq, UART_PLL_FREQ},
     pac,
@@ -30,9 +30,9 @@ fn main() -> ! {
 
     loop {
         gpio5.set_high().unwrap();
-        d.delay_ms(1000).unwrap();
+        d.delay_ms(1000);
 
         gpio5.set_low().unwrap();
-        d.delay_ms(1000).unwrap();
+        d.delay_ms(1000);
     }
 }

--- a/examples/led_interrupt_switch.rs
+++ b/examples/led_interrupt_switch.rs
@@ -3,8 +3,8 @@
 
 use bl602_hal as hal;
 use core::mem::MaybeUninit;
-use embedded_hal::digital::blocking::OutputPin;
-use embedded_hal::digital::blocking::StatefulOutputPin;
+use embedded_hal::digital::OutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use hal::{interrupts::*, pac, prelude::*};
 use panic_halt as _;
 

--- a/examples/led_timer_interrupt.rs
+++ b/examples/led_timer_interrupt.rs
@@ -17,8 +17,8 @@ use bl602_hal as hal;
 use core::cell::RefCell;
 use core::ops::DerefMut;
 use critical_section::{self, Mutex};
-use embedded_hal::digital::blocking::{OutputPin, ToggleableOutputPin};
-use embedded_hal::timer::nb::CountDown;
+use embedded_hal::digital::{OutputPin, ToggleableOutputPin};
+use embedded_hal_zero::timer::CountDown;
 use embedded_time::{duration::*, rate::*};
 use hal::{
     clock::{Strict, SysclkFreq},
@@ -107,7 +107,7 @@ fn main() -> ! {
     // a timer without needing to configure any match values or handle any interrupts:
     loop {
         // Start the timer's CountDown functionality. The countdown will last 3000ms.
-        timer_ch1.start(3_000u32.milliseconds()).ok();
+        timer_ch1.start(3_000u32.milliseconds());
         // The .wait() function returns an error until the timer has finished counting down.
         while timer_ch1.wait().is_err() {
             // Stay in the while loop until the timer is done.

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -3,7 +3,7 @@
 
 use bl602_hal as hal;
 use core::fmt::Write;
-use embedded_hal::delay::blocking::DelayMs;
+use embedded_hal::delay::DelayUs;
 use hal::{
     clock::{Strict, SysclkFreq, UART_PLL_FREQ},
     pac,
@@ -44,6 +44,6 @@ fn main() -> ! {
 
     loop {
         serial.write_str("Hello Rust\r\n").ok();
-        d.delay_ms(1000).unwrap();
+        d.delay_ms(1000);
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -27,7 +27,7 @@ use crate::delay::*;
 use crate::gpio::ClkCfg;
 use crate::pac;
 use core::num::NonZeroU32;
-use embedded_hal::delay::blocking::DelayUs;
+use embedded_hal::delay::DelayUs;
 use embedded_time::rate::{Extensions, Hertz};
 
 /// Internal high-speed RC oscillator frequency

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -367,13 +367,13 @@ fn glb_set_system_clk_div(hclkdiv: u8, bclkdiv: u8) {
     let mut delay = McycleDelay::new(system_core_clock_get());
 
     // This delay used to be 8 NOPS (1/4 us). Might need to be replaced again.
-    delay.delay_us(1).unwrap();
+    delay.delay_us(1);
 
     unsafe { &*pac::GLB::ptr() }
         .clk_cfg0
         .modify(|_, w| w.reg_hclk_en().set_bit().reg_bclk_en().set_bit());
 
-    delay.delay_us(1).unwrap();
+    delay.delay_us(1);
 }
 
 // This is a reference implementation of `PDS_Select_XTAL_As_PLL_Ref`.
@@ -532,7 +532,7 @@ fn pds_power_on_pll(freq: u32) {
     pds.pu_rst_clkpll
         .modify(|_, w| w.pu_clkpll_sfreg().set_bit());
 
-    delay.delay_us(5).unwrap();
+    delay.delay_us(5);
 
     pds.pu_rst_clkpll.modify(|_, w| w.pu_clkpll().set_bit());
 
@@ -547,22 +547,22 @@ fn pds_power_on_pll(freq: u32) {
             .set_bit()
     });
 
-    delay.delay_us(5).unwrap();
+    delay.delay_us(5);
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_sdm_reset().set_bit());
 
-    delay.delay_us(1).unwrap();
+    delay.delay_us(1);
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_reset_fbdv().set_bit());
 
-    delay.delay_us(2).unwrap();
+    delay.delay_us(2);
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_reset_fbdv().clear_bit());
 
-    delay.delay_us(1).unwrap();
+    delay.delay_us(1);
 
     pds.pu_rst_clkpll
         .modify(|_, w| w.clkpll_sdm_reset().clear_bit());
@@ -576,7 +576,7 @@ fn aon_power_on_xtal() -> Result<(), &'static str> {
     let mut delaysrc = McycleDelay::new(system_core_clock_get());
     let mut timeout: u32 = 0;
 
-    delaysrc.delay_us(10).unwrap();
+    delaysrc.delay_us(10);
 
     while unsafe { &*pac::AON::ptr() }
         .tsen
@@ -585,7 +585,7 @@ fn aon_power_on_xtal() -> Result<(), &'static str> {
         .bit_is_clear()
         && timeout < 120
     {
-        delaysrc.delay_us(10).unwrap();
+        delaysrc.delay_us(10);
         timeout += 1;
     }
 
@@ -653,7 +653,7 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     pds_power_on_pll_rom(xtal_freq);
 
     let mut delay = McycleDelay::new(system_core_clock_get());
-    delay.delay_us(55).unwrap();
+    delay.delay_us(55);
 
     pds_enable_pll_all_clks();
 
@@ -695,7 +695,7 @@ fn glb_set_system_clk_pll(target_core_clk: u32, xtal_freq: u32) {
     let mut delay = McycleDelay::new(system_core_clock_get());
 
     // This delay used to be 8 NOPS (1/4 us). (GLB_CLK_SET_DUMMY_WAIT) Might need to be replaced again.
-    delay.delay_us(1).unwrap();
+    delay.delay_us(1);
 
     // use 120Mhz PLL tap for PKA clock since we're using PLL
     // NOTE: This isn't documented in the datasheet!

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,7 +1,8 @@
 //! Delays
 
 use core::convert::Infallible;
-use embedded_hal::delay::blocking::{DelayMs, DelayUs};
+use embedded_hal_zero::blocking::delay::{DelayMs as DelayMsZero, DelayUs as DelayUsZero};
+use embedded_hal::delay::DelayUs;
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
 ///
@@ -43,9 +44,28 @@ impl McycleDelay {
     }
 }
 
-impl DelayUs<u64> for McycleDelay {
-    type Error = Infallible;
+// Embedded Hal 1.0 traits
+impl DelayUs for McycleDelay {
+    /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
+    #[inline]
+    fn delay_us(&mut self, us: u64) -> Result<(), Infallible> {
+        McycleDelay::delay_cycles((us * (self.core_frequency as u64)) / 1_000_000);
 
+        Ok(())
+    }
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
+        McycleDelay::delay_cycles((ms * (self.core_frequency as u64)) / 1000);
+
+        Ok(())
+    }
+}
+
+// Embedded-hal 0.2 traits
+
+// Embedded Hal 1.0 traits
+impl DelayUsZero<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
     fn delay_us(&mut self, us: u64) -> Result<(), Infallible> {
@@ -55,9 +75,7 @@ impl DelayUs<u64> for McycleDelay {
     }
 }
 
-impl DelayMs<u64> for McycleDelay {
-    type Error = Infallible;
-
+impl DelayMsZero<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]
     fn delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,6 +1,5 @@
 //! Delays
 
-use core::convert::Infallible;
 use embedded_hal_zero::blocking::delay::{DelayMs as DelayMsZero, DelayUs as DelayUsZero};
 use embedded_hal::delay::DelayUs;
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,7 +1,7 @@
 //! Delays
 
-use embedded_hal_zero::blocking::delay::{DelayMs as DelayMsZero, DelayUs as DelayUsZero};
 use embedded_hal::delay::DelayUs;
+use embedded_hal_zero::blocking::delay::{DelayMs as DelayMsZero, DelayUs as DelayUsZero};
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
 ///

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -66,6 +66,63 @@ impl DelayUsZero<u64> for McycleDelay {
     }
 }
 
+// Call DelayMsZero::<u64>::delay_ms for all of u8/u16/u32/i8/i16/i32/i64
+impl DelayMsZero<u8> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: u8) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
+impl DelayMsZero<u16> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: u16) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
+impl DelayMsZero<u32> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: u32) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
+impl DelayMsZero<i8> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: i8) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
+impl DelayMsZero<i16> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: i16) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
+impl DelayMsZero<i32> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: i32) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
+impl DelayMsZero<i64> for McycleDelay {
+    /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
+    #[inline]
+    fn delay_ms(&mut self, ms: i64) {
+        DelayMsZero::<u64>::delay_ms(self, ms as u64);
+    }
+}
+
 impl DelayMsZero<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -44,43 +44,33 @@ impl McycleDelay {
     }
 }
 
-// Embedded Hal 1.0 traits
+// embedded-hal 1.0 traits
 impl DelayUs for McycleDelay {
     /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
-    fn delay_us(&mut self, us: u64) -> Result<(), Infallible> {
-        McycleDelay::delay_cycles((us * (self.core_frequency as u64)) / 1_000_000);
-
-        Ok(())
+    fn delay_us(&mut self, us: u32) {
+        McycleDelay::delay_cycles((us as u64 * (self.core_frequency as u64)) / 1_000_000);
     }
     /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]
-    fn delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
-        McycleDelay::delay_cycles((ms * (self.core_frequency as u64)) / 1000);
-
-        Ok(())
+    fn delay_ms(&mut self, ms: u32) {
+        McycleDelay::delay_cycles((ms as u64 * (self.core_frequency as u64)) / 1000);
     }
 }
 
-// Embedded-hal 0.2 traits
-
-// Embedded Hal 1.0 traits
+// embedded-hal 0.2 traits
 impl DelayUsZero<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
-    fn delay_us(&mut self, us: u64) -> Result<(), Infallible> {
+    fn delay_us(&mut self, us: u64) {
         McycleDelay::delay_cycles((us * (self.core_frequency as u64)) / 1_000_000);
-
-        Ok(())
     }
 }
 
 impl DelayMsZero<u64> for McycleDelay {
     /// Performs a busy-wait loop until the number of milliseconds `ms` has elapsed
     #[inline]
-    fn delay_ms(&mut self, ms: u64) -> Result<(), Infallible> {
+    fn delay_ms(&mut self, ms: u64) {
         McycleDelay::delay_cycles((ms * (self.core_frequency as u64)) / 1000);
-
-        Ok(())
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -280,7 +280,7 @@ macro_rules! impl_glb {
         pub mod pin {
             use core::marker::PhantomData;
             use core::convert::Infallible;
-            use embedded_hal::digital::blocking::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
+            use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
             use embedded_hal_zero::digital::v2::{
                 InputPin as InputPinZero,
                 OutputPin as OutputPinZero,
@@ -456,8 +456,6 @@ macro_rules! impl_glb {
 
 
             impl<MODE> InputPin for $Pini<Input<MODE>> {
-                type Error = Infallible;
-
                 fn is_high(&self) -> Result<bool, Self::Error> {
                     Ok(self.is_high_inner())
                 }
@@ -540,8 +538,6 @@ macro_rules! impl_glb {
 
 
             impl<MODE> OutputPin for $Pini<Output<MODE>> {
-                type Error = Infallible;
-
                 fn set_high(&mut self) -> Result<(), Self::Error> {
                     self.set_high_inner();
                     Ok(())
@@ -589,8 +585,6 @@ macro_rules! impl_glb {
 
 
             impl<MODE> ToggleableOutputPin for $Pini<Output<MODE>> {
-                type Error = Infallible;
-
                 fn toggle(&mut self) -> Result<(), Self::Error> {
                     if self.is_output_high_inner() {
                         self.set_low_inner()

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -454,6 +454,9 @@ macro_rules! impl_glb {
                 }
             }
 
+            impl<MODE> embedded_hal::digital::ErrorType for $Pini<Input<MODE>> {
+                type Error = Infallible;
+            }
 
             impl<MODE> InputPin for $Pini<Input<MODE>> {
                 fn is_high(&self) -> Result<bool, Self::Error> {
@@ -536,6 +539,9 @@ macro_rules! impl_glb {
                 }
             }
 
+            impl<MODE> embedded_hal::digital::ErrorType for $Pini<Output<MODE>> {
+                type Error = Infallible;
+            }
 
             impl<MODE> OutputPin for $Pini<Output<MODE>> {
                 fn set_high(&mut self) -> Result<(), Self::Error> {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -19,8 +19,6 @@
 
 use bl602_pac::I2C;
 use embedded_hal::i2c as i2cAlpha;
-// use embedded_hal::i2c::Read as ReadAlpha;
-// use embedded_hal::i2c::Write as WriteAlpha;
 use embedded_hal_zero::blocking::i2c::Read as ReadZero;
 use embedded_hal_zero::blocking::i2c::Write as WriteZero;
 use embedded_time::rate::Hertz;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -326,23 +326,14 @@ where
         Ok(())
     }
 
-    // untested!
+    /// We can't meet the conttract for transaction, leaving it as unimplemented for now.
+    /// https://github.com/rust-embedded/embedded-hal/blob/bf2b8a11fde064194ae5c70642b579051de631c8/embedded-hal/src/i2c.rs#L361
     fn transaction(
         &mut self,
-        address: i2cAlpha::SevenBitAddress,
-        operations: &mut [i2cAlpha::Operation<'_>],
+        _address: i2cAlpha::SevenBitAddress,
+        _operations: &mut [i2cAlpha::Operation<'_>],
     ) -> Result<(), Self::Error> {
-        for op in operations {
-            let result = match op {
-                i2cAlpha::Operation::Read(buf) => i2cAlpha::I2c::read(self, address, buf),
-                i2cAlpha::Operation::Write(buf) => i2cAlpha::I2c::write(self, address, buf),
-            };
-            if result.is_err() {
-                return result;
-            }
-        }
-
-        Ok(())
+        unimplemented!()
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -19,8 +19,8 @@
 
 use bl602_pac::I2C;
 use embedded_hal::i2c as i2cAlpha;
-use embedded_hal::i2c::blocking::Read as ReadAlpha;
-use embedded_hal::i2c::blocking::Write as WriteAlpha;
+// use embedded_hal::i2c::Read as ReadAlpha;
+// use embedded_hal::i2c::Write as WriteAlpha;
 use embedded_hal_zero::blocking::i2c::Read as ReadZero;
 use embedded_hal_zero::blocking::i2c::Write as WriteZero;
 use embedded_time::rate::Hertz;
@@ -175,12 +175,10 @@ where
     }
 }
 
-impl<PINS> ReadAlpha<i2cAlpha::SevenBitAddress> for I2c<pac::I2C, PINS>
+impl<PINS> i2cAlpha::I2c<i2cAlpha::SevenBitAddress> for I2c<pac::I2C, PINS>
 where
     PINS: Pins<pac::I2C>,
 {
-    type Error = Error;
-
     fn read(
         &mut self,
         address: i2cAlpha::SevenBitAddress,
@@ -243,13 +241,6 @@ where
 
         Ok(())
     }
-}
-
-impl<PINS> WriteAlpha<i2cAlpha::SevenBitAddress> for I2c<pac::I2C, PINS>
-where
-    PINS: Pins<pac::I2C>,
-{
-    type Error = Error;
 
     fn write(
         &mut self,
@@ -327,7 +318,7 @@ where
     type Error = Error;
 
     fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        ReadAlpha::read(self, address, buffer)
+        i2cAlpha::I2c::read(self, address, buffer)
     }
 }
 
@@ -338,6 +329,6 @@ where
     type Error = Error;
 
     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
-        WriteAlpha::write(self, addr, bytes)
+        i2cAlpha::I2c::write(self, addr, bytes)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -42,6 +42,18 @@ pub enum Error {
     Timeout,
 }
 
+impl embedded_hal::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal::i2c::ErrorKind {
+        match self {
+            Self::RxOverflow => embedded_hal::i2c::ErrorKind::Overrun,
+            Self::TxOverflow => embedded_hal::i2c::ErrorKind::Overrun,
+            Self::RxUnderflow => embedded_hal::i2c::ErrorKind::Overrun,
+            Self::TxUnderflow => embedded_hal::i2c::ErrorKind::Overrun,
+            Self::Timeout => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
+        }
+    }
+}
+
 /// SDA pins - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait SdaPin<I2C> {}
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -175,6 +175,10 @@ where
     }
 }
 
+impl<PINS> i2cAlpha::ErrorType for  I2c<pac::I2C, PINS> {
+    type Error = Error;
+}
+
 impl<PINS> i2cAlpha::I2c<i2cAlpha::SevenBitAddress> for I2c<pac::I2C, PINS>
 where
     PINS: Pins<pac::I2C>,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -325,6 +325,29 @@ where
 
         Ok(())
     }
+
+    // untested!
+    fn transaction(
+            &mut self,
+            address: i2cAlpha::SevenBitAddress,
+            operations: &mut [i2cAlpha::Operation<'_>],
+        ) -> Result<(), Self::Error> {
+        for op in operations {
+            let result = match op {
+                i2cAlpha::Operation::Read(buf) => {
+                    i2cAlpha::I2c::read(self, address,  buf)
+                },
+                i2cAlpha::Operation::Write(buf) => {
+                    i2cAlpha::I2c::write(self, address, buf)
+                },
+            };
+            if result.is_err(){
+                return result;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<PINS> ReadZero for I2c<pac::I2C, PINS>

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -47,7 +47,9 @@ impl embedded_hal::i2c::Error for Error {
             Self::TxOverflow => embedded_hal::i2c::ErrorKind::Overrun,
             Self::RxUnderflow => embedded_hal::i2c::ErrorKind::Overrun,
             Self::TxUnderflow => embedded_hal::i2c::ErrorKind::Overrun,
-            Self::Timeout => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
+            Self::Timeout => embedded_hal::i2c::ErrorKind::NoAcknowledge(
+                embedded_hal::i2c::NoAcknowledgeSource::Address,
+            ),
         }
     }
 }
@@ -185,7 +187,7 @@ where
     }
 }
 
-impl<PINS> i2cAlpha::ErrorType for  I2c<pac::I2C, PINS> {
+impl<PINS> i2cAlpha::ErrorType for I2c<pac::I2C, PINS> {
     type Error = Error;
 }
 
@@ -326,20 +328,16 @@ where
 
     // untested!
     fn transaction(
-            &mut self,
-            address: i2cAlpha::SevenBitAddress,
-            operations: &mut [i2cAlpha::Operation<'_>],
-        ) -> Result<(), Self::Error> {
+        &mut self,
+        address: i2cAlpha::SevenBitAddress,
+        operations: &mut [i2cAlpha::Operation<'_>],
+    ) -> Result<(), Self::Error> {
         for op in operations {
             let result = match op {
-                i2cAlpha::Operation::Read(buf) => {
-                    i2cAlpha::I2c::read(self, address,  buf)
-                },
-                i2cAlpha::Operation::Write(buf) => {
-                    i2cAlpha::I2c::write(self, address, buf)
-                },
+                i2cAlpha::Operation::Read(buf) => i2cAlpha::I2c::read(self, address, buf),
+                i2cAlpha::Operation::Write(buf) => i2cAlpha::I2c::write(self, address, buf),
             };
-            if result.is_err(){
+            if result.is_err() {
                 return result;
             }
         }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -252,6 +252,10 @@ where
     }
 }
 
+impl<UART, PINS>  embedded_hal_nb::serial::ErrorType for Serial<UART, PINS>{
+    type Error = Error;
+}
+
 impl<UART, PINS> embedded_hal_nb::serial::Write for Serial<UART, PINS>
 where
     UART: Deref<Target = pac::uart0::RegisterBlock>,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -4,6 +4,7 @@ use crate::pac;
 use core::fmt;
 use core::ops::Deref;
 use embedded_hal_nb;
+use embedded_hal_nb::serial::Write;
 use embedded_time::rate::{Baud, Extensions};
 use nb::block;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -22,6 +22,17 @@ pub enum Error {
     Parity,
 }
 
+impl embedded_hal_nb::serial::Error for Error {
+    fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
+        match self {
+            Error::Framing => embedded_hal_nb::serial::ErrorKind::FrameFormat,
+            Error::Noise => embedded_hal_nb::serial::ErrorKind::Noise,
+            Error::Overrun => embedded_hal_nb::serial::ErrorKind::Overrun,
+            Error::Parity => embedded_hal_nb::serial::ErrorKind::Parity,
+        }
+    }
+}
+
 /// Serial configuration
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Config {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -264,7 +264,7 @@ where
     }
 }
 
-impl<UART, PINS>  embedded_hal_nb::serial::ErrorType for Serial<UART, PINS>{
+impl<UART, PINS> embedded_hal_nb::serial::ErrorType for Serial<UART, PINS> {
     type Error = Error;
 }
 
@@ -303,8 +303,7 @@ where
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         if self.uart.uart_fifo_config_1.read().rx_fifo_cnt().bits() == 0 {
             Err(nb::Error::WouldBlock)
-        }
-        else {
+        } else {
             let ans = self.uart.uart_fifo_rdata.read().bits();
             Ok((ans & 0xff) as u8)
         }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,8 +3,7 @@ use crate::clock::Clocks;
 use crate::pac;
 use core::fmt;
 use core::ops::Deref;
-use embedded_hal::serial::nb::Write as WriteOne;
-use embedded_hal::serial::nb::Read as ReadOne;
+use embedded_hal_nb;
 use embedded_time::rate::{Baud, Extensions};
 use nb::block;
 
@@ -253,12 +252,10 @@ where
     }
 }
 
-impl<UART, PINS> embedded_hal::serial::nb::Write<u8> for Serial<UART, PINS>
+impl<UART, PINS> embedded_hal_nb::serial::Write for Serial<UART, PINS>
 where
     UART: Deref<Target = pac::uart0::RegisterBlock>,
 {
-    type Error = Error;
-
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
         // If there's no room to write a byte or more to the FIFO, return WouldBlock
         if self.uart.uart_fifo_config_1.read().tx_fifo_cnt().bits() == 0 {
@@ -283,12 +280,10 @@ where
     }
 }
 
-impl<UART, PINS> embedded_hal::serial::nb::Read<u8> for Serial<UART, PINS>
+impl<UART, PINS> embedded_hal_nb::serial::Read<u8> for Serial<UART, PINS>
 where
     UART: Deref<Target = pac::uart0::RegisterBlock>,
 {
-    type Error = Error;
-
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         if self.uart.uart_fifo_config_1.read().rx_fifo_cnt().bits() == 0 {
             Err(nb::Error::WouldBlock)
@@ -307,11 +302,11 @@ where
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
-        WriteOne::write(self, word)
+        embedded_hal_nb::serial::Write::write(self, word)
     }
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        WriteOne::flush(self)
+        embedded_hal_nb::serial::Write::flush(self)
     }
 }
 
@@ -322,13 +317,13 @@ where
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
-        ReadOne::read(self)
+        embedded_hal_nb::serial::Read::read(self)
     }
 }
 
 impl<UART, PINS> fmt::Write for Serial<UART, PINS>
 where
-    Serial<UART, PINS>: embedded_hal::serial::nb::Write<u8>,
+    Serial<UART, PINS>: embedded_hal_nb::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         s.as_bytes()

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -45,6 +45,17 @@ pub enum Error {
     TxUnderflow,
 }
 
+impl embedded_hal_nb::spi::Error for Error {
+    fn kind(&self) -> embedded_hal_nb::spi::ErrorKind {
+        match self {
+            Self::RxOverflow => embedded_hal_nb::spi::ErrorKind::Overrun,
+            Self::TxOverflow => embedded_hal_nb::spi::ErrorKind::Overrun,
+            Self::RxUnderflow => embedded_hal_nb::spi::ErrorKind::Overrun,
+            Self::TxUnderflow => embedded_hal_nb::spi::ErrorKind::Overrun,
+        }
+    }
+}
+
 /// The bit format to send the data in
 #[derive(Debug, Clone, Copy)]
 pub enum SpiBitFormat {
@@ -211,6 +222,12 @@ where
             .write(|w| w.rx_fifo_clr().set_bit().tx_fifo_clr().set_bit());
     }
 }
+
+
+impl<PINS> embedded_hal_nb::spi::ErrorType for Spi<pac::SPI, PINS>{
+    type Error = Error;
+}
+
 
 impl<PINS> embedded_hal_nb::spi::FullDuplex<u8> for Spi<pac::SPI, PINS>
 where

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -22,8 +22,8 @@
 */
 
 use bl602_pac::SPI;
-use embedded_hal_nb;
 pub use embedded_hal::spi::Mode;
+use embedded_hal_nb;
 use embedded_hal_zero::spi::FullDuplex as FullDuplexZero;
 use embedded_time::rate::Hertz;
 
@@ -223,11 +223,9 @@ where
     }
 }
 
-
-impl<PINS> embedded_hal_nb::spi::ErrorType for Spi<pac::SPI, PINS>{
+impl<PINS> embedded_hal_nb::spi::ErrorType for Spi<pac::SPI, PINS> {
     type Error = Error;
 }
-
 
 impl<PINS> embedded_hal_nb::spi::FullDuplex<u8> for Spi<pac::SPI, PINS>
 where
@@ -292,7 +290,6 @@ impl<PINS> embedded_hal_zero::blocking::spi::write::Default<u8> for Spi<pac::SPI
     PINS: Pins<pac::SPI>
 {
 }
-
 
 impl<PINS> embedded_hal_zero::blocking::spi::write_iter::Default<u8> for Spi<pac::SPI, PINS> where
     PINS: Pins<pac::SPI>

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -22,8 +22,7 @@
 */
 
 use bl602_pac::SPI;
-pub use embedded_hal::spi::blocking::Transfer;
-use embedded_hal::spi::nb::FullDuplex;
+use embedded_hal_nb;
 pub use embedded_hal::spi::Mode;
 use embedded_hal_zero::spi::FullDuplex as FullDuplexZero;
 use embedded_time::rate::Hertz;
@@ -213,12 +212,10 @@ where
     }
 }
 
-impl<PINS> FullDuplex<u8> for Spi<pac::SPI, PINS>
+impl<PINS> embedded_hal_nb::spi::FullDuplex<u8> for Spi<pac::SPI, PINS>
 where
     PINS: Pins<pac::SPI>,
 {
-    type Error = Error;
-
     fn read(&mut self) -> nb::Result<u8, Error> {
         let spi_fifo_config_0 = self.spi.spi_fifo_config_0.read();
 
@@ -259,11 +256,11 @@ where
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Error> {
-        FullDuplex::read(self)
+        embedded_hal_nb::spi::FullDuplex::read(self)
     }
 
     fn send(&mut self, data: u8) -> nb::Result<(), Self::Error> {
-        FullDuplex::write(self, data)
+        embedded_hal_nb::spi::FullDuplex::write(self, data)
     }
 }
 
@@ -274,72 +271,13 @@ impl<PINS> embedded_hal_zero::blocking::spi::transfer::Default<u8> for Spi<pac::
 {
 }
 
-// This is basically the default impl of spi::blocking::Transfer from e-h 0.2
-impl<PINS> embedded_hal::spi::blocking::Transfer<u8> for Spi<pac::SPI, PINS>
-where
-    PINS: Pins<pac::SPI>,
-{
-    type Error = Error;
-
-    fn transfer(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-        for word in words.iter_mut() {
-            nb::block!(self.send(*word))?;
-            *word = nb::block!(FullDuplexZero::read(self))?;
-        }
-
-        Ok(())
-    }
-}
-
 impl<PINS> embedded_hal_zero::blocking::spi::write::Default<u8> for Spi<pac::SPI, PINS> where
     PINS: Pins<pac::SPI>
 {
 }
 
-// This is basically the default impl of spi::blocking::write from e-h 0.2
-impl<PINS> embedded_hal::spi::blocking::Write<u8> for Spi<pac::SPI, PINS>
-where
-    PINS: Pins<pac::SPI>,
-{
-    type Error = Error;
-    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        for word in words {
-            nb::block!(self.send(*word))?;
-            nb::block!(FullDuplexZero::read(self))?;
-        }
-
-        Ok(())
-    }
-}
 
 impl<PINS> embedded_hal_zero::blocking::spi::write_iter::Default<u8> for Spi<pac::SPI, PINS> where
     PINS: Pins<pac::SPI>
 {
 }
-
-// This is basically the default impl of spi::blocking::write_iter from e-h 0.2
-impl<PINS> embedded_hal::spi::blocking::WriteIter<u8> for Spi<pac::SPI, PINS>
-where
-    PINS: Pins<pac::SPI>,
-{
-    type Error = Error;
-    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
-    where
-        WI: IntoIterator<Item = u8>,
-    {
-        for word in words.into_iter() {
-            nb::block!(self.send(word))?;
-            nb::block!(FullDuplexZero::read(self))?;
-        }
-
-        Ok(())
-    }
-}
-
-// This one didnt exist in 0.2
-// Haven't worked out how to satisy it yet.
-
-// impl<PINS> embedded_hal::spi::blocking::Transactional<u8> for Spi<pac::SPI, PINS> where
-//     PINS: Pins<pac::SPI>
-// {
-// }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -294,9 +294,7 @@ macro_rules! impl_timer_channel {
             }
         }
 
-        impl embedded_hal::timer::nb::CountDown for $conf_name {
-            type Error = CountDownError;
-
+        impl embedded_hal_zero::timer::CountDown for $conf_name {
             type Time = Nanoseconds::<u64>;
 
             fn start<T>(&mut self, count: T) -> Result<(), Self::Error>

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -297,7 +297,7 @@ macro_rules! impl_timer_channel {
         impl embedded_hal_zero::timer::CountDown for $conf_name {
             type Time = Nanoseconds::<u64>;
 
-            fn start<T>(&mut self, count: T) -> Result<(), Self::Error>
+            fn start<T>(&mut self, count: T) -> Result<(), CountDownError>
             where
                 T: Into<Self::Time>,
             {
@@ -308,7 +308,7 @@ macro_rules! impl_timer_channel {
                 Ok(())
             }
 
-            fn wait(&mut self) -> nb::Result<(), Self::Error> {
+            fn wait(&mut self) -> nb::Result<(), CountDownError> {
                 match self.count_down_target {
                     Some(nanos) => {
                         let current_time = self.current_time();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -40,6 +40,7 @@ use bl602_pac::TIMER;
 use core::cell::RefCell;
 use embedded_time::{duration::*, rate::*};
 use paste::paste;
+use void::Void;
 
 /// Error for [CountDown](embedded_hal::timer::CountDown)
 #[derive(Debug)]
@@ -297,7 +298,7 @@ macro_rules! impl_timer_channel {
         impl embedded_hal_zero::timer::CountDown for $conf_name {
             type Time = Nanoseconds::<u64>;
 
-            fn start<T>(&mut self, count: T) -> Result<(), CountDownError>
+            fn start<T>(&mut self, count: T)
             where
                 T: Into<Self::Time>,
             {
@@ -305,10 +306,9 @@ macro_rules! impl_timer_channel {
                     Nanoseconds::<u64>::new(self.current_time().0 + count.into().0)
                 );
                 self.last_count_down_value = None;
-                Ok(())
             }
 
-            fn wait(&mut self) -> nb::Result<(), CountDownError> {
+            fn wait(&mut self) -> Result<(), nb::Error<Void>> {
                 match self.count_down_target {
                     Some(nanos) => {
                         let current_time = self.current_time();
@@ -317,13 +317,9 @@ macro_rules! impl_timer_channel {
                             Ok(())
                         } else {
                             match self.last_count_down_value {
-                                Some(last_count_down_value) => {
-                                    if current_time < last_count_down_value {
-                                        Err(nb::Error::Other(CountDownError::Wrapped))
-                                    } else {
-                                        self.last_count_down_value = Some(current_time);
-                                        Err(nb::Error::WouldBlock)
-                                    }
+                                Some(_) => {
+                                    self.last_count_down_value = Some(current_time);
+                                    Err(nb::Error::WouldBlock)
                                 }
                                 None => {
                                     self.last_count_down_value = Some(current_time);

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -229,12 +229,10 @@ impl ConfiguredWatchdog0 {
     }
 }
 
-impl embedded_hal::watchdog::blocking::Watchdog for ConfiguredWatchdog0 {
-    type Error = WatchdogError;
-
+impl embedded_hal_zero::watchdog::Watchdog for ConfiguredWatchdog0 {
     /// This feeds the watchdog by resetting its counter value to 0.
     /// WCR register is write-only, no need to preserve register contents
-    fn feed(&mut self) -> Result<(), Self::Error> {
+    fn feed(&mut self) -> Result<(), WatchdogError> {
         let timer = unsafe { &*pac::TIMER::ptr() };
         send_access_codes();
         timer.wcr.write(|w| w.wcr().set_bit());
@@ -242,11 +240,8 @@ impl embedded_hal::watchdog::blocking::Watchdog for ConfiguredWatchdog0 {
     }
 }
 
-impl embedded_hal::watchdog::blocking::Disable for ConfiguredWatchdog0 {
-    type Error = WatchdogError;
-    type Target = ConfiguredWatchdog0;
-
-    fn disable(self) -> Result<Self::Target, Self::Error> {
+impl embedded_hal_zero::watchdog::WatchdogDisable for ConfiguredWatchdog0 {
+    fn disable(self) -> Result<ConfiguredWatchdog0, WatchdogError> {
         let timer = unsafe { &*pac::TIMER::ptr() };
         send_access_codes();
         timer.wmer.write(|w| w.we().clear_bit());
@@ -254,12 +249,10 @@ impl embedded_hal::watchdog::blocking::Disable for ConfiguredWatchdog0 {
     }
 }
 
-impl embedded_hal::watchdog::blocking::Enable for ConfiguredWatchdog0 {
-    type Error = WatchdogError;
+impl embedded_hal_zero::watchdog::WatchdogEnable for ConfiguredWatchdog0 {
     type Time = Nanoseconds<u64>;
-    type Target = ConfiguredWatchdog0;
 
-    fn start<T>(self, period: T) -> Result<Self::Target, Self::Error>
+    fn start<T>(self, period: T) -> Result<ConfiguredWatchdog0, WatchdogError>
     where
         T: Into<Self::Time>,
     {

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -232,33 +232,30 @@ impl ConfiguredWatchdog0 {
 impl embedded_hal_zero::watchdog::Watchdog for ConfiguredWatchdog0 {
     /// This feeds the watchdog by resetting its counter value to 0.
     /// WCR register is write-only, no need to preserve register contents
-    fn feed(&mut self) -> Result<(), WatchdogError> {
+    fn feed(&mut self) -> () {
         let timer = unsafe { &*pac::TIMER::ptr() };
         send_access_codes();
         timer.wcr.write(|w| w.wcr().set_bit());
-        Ok(())
     }
 }
 
 impl embedded_hal_zero::watchdog::WatchdogDisable for ConfiguredWatchdog0 {
-    fn disable(self) -> Result<ConfiguredWatchdog0, WatchdogError> {
+    fn disable(&mut self) {
         let timer = unsafe { &*pac::TIMER::ptr() };
         send_access_codes();
         timer.wmer.write(|w| w.we().clear_bit());
-        Ok(self)
     }
 }
 
 impl embedded_hal_zero::watchdog::WatchdogEnable for ConfiguredWatchdog0 {
     type Time = Nanoseconds<u64>;
 
-    fn start<T>(self, period: T) -> Result<ConfiguredWatchdog0, WatchdogError>
+    fn start<T>(&mut self, period: T)
     where
         T: Into<Self::Time>,
     {
         self.set_timeout(period);
         self.enable();
-        Ok(self)
     }
 }
 


### PR DESCRIPTION
Update all drivers to use embedded-hal 1.0 alpha 11 where possible.
Port all nb drivers to use embedded-hal-nb 1.0 alpha 3.
Move any remaining drivers using removed embedded-hal 1.0 alpha traits to embedded-hal 0.2 traits.
Update the examples to make them build again after all of the above.

Notes:
- examples still have warnings
- i2c transactional is new and untested
- i have not run any of the examples to ensure there is no new breakage

Wait until testing is complete before merging, but you can review at any time.
Please squash this PR when merging.