### PR TITLE
embedded-hal 1.0 rc3 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
         include:
           # Run check with MSRV as well
-          - rust: 1.59.0
+          - rust: 1.60.0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
         include:
           # Run check with MSRV as well
-          - rust: 1.65.0
+          - rust: 1.60.0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
         include:
           # Run check with MSRV as well
-          - rust: 1.60.0
+          - rust: 1.65.0
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ critical-section = "1.1"
 
 [build-dependencies]
 riscv-target = "0.1.2"
+# riscv-target depends on regex, which depends on memchr.
+# memchr bumped it's MSRV to 1.61 midway through 2.6.x releases
+# regex increased it's MSRV to 1.65 in release 1.10.x
+# pinning regex to 1.8.4 and memchr to 2.5.0 until we bump MSRV
+regex = "=1.8.4"
+memchr = "=2.5.0"
 
 [features]
 default = ["critical-section-impl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ description = "HAL for the bl602 microcontroller"
 
 [dependencies]
 bl602-pac = { git = "https://github.com/sipeed/bl602-pac", branch = "main" }
-embedded-hal = "=1.0.0-rc.1"
-embedded-hal-nb = "=1.0.0-rc.1"
+embedded-hal = "=1.0.0-rc.3"
+embedded-hal-nb = "=1.0.0-rc.3"
 embedded-time = "0.12.0"
 riscv = "0.10.1"
 nb = "1.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Matrix: [#bl602-rust:matrix.org](https://matrix.to/#/#bl602-rust:matrix.org)
 
 ## Minimum Supported Rust Version
 
-The minimum supported Rust version (MSRV) for this project is Rust **v1.65.0**. The
+The minimum supported Rust version (MSRV) for this project is Rust **v1.60.0**. The
 project might build on earlier versions, but this is the earliest version that
 is expected to work.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Matrix: [#bl602-rust:matrix.org](https://matrix.to/#/#bl602-rust:matrix.org)
 
 ## Minimum Supported Rust Version
 
-The minimum supported Rust version (MSRV) for this project is Rust **v1.59.0**. The
+The minimum supported Rust version (MSRV) for this project is Rust **v1.60.0**. The
 project might build on earlier versions, but this is the earliest version that
 is expected to work.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Matrix: [#bl602-rust:matrix.org](https://matrix.to/#/#bl602-rust:matrix.org)
 
 ## Minimum Supported Rust Version
 
-The minimum supported Rust version (MSRV) for this project is Rust **v1.60.0**. The
+The minimum supported Rust version (MSRV) for this project is Rust **v1.65.0**. The
 project might build on earlier versions, but this is the earliest version that
 is expected to work.
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -27,7 +27,7 @@ use crate::delay::*;
 use crate::gpio::ClkCfg;
 use crate::pac;
 use core::num::NonZeroU32;
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_time::rate::{Extensions, Hertz};
 
 /// Internal high-speed RC oscillator frequency

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,6 +1,6 @@
 //! Delays
 
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal_zero::blocking::delay::{DelayMs as DelayMsZero, DelayUs as DelayUsZero};
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
@@ -44,7 +44,11 @@ impl McycleDelay {
 }
 
 // embedded-hal 1.0 traits
-impl DelayUs for McycleDelay {
+impl DelayNs for McycleDelay {
+    /// Performs a busy-wait loop until the number of nanoseconds `ns` has elapsed
+    fn delay_ns(&mut self, ns: u32) {
+        McycleDelay::delay_cycles((ns as u64 * (self.core_frequency as u64)) / 1_000_000_000);
+    }
     /// Performs a busy-wait loop until the number of microseconds `us` has elapsed
     #[inline]
     fn delay_us(&mut self, us: u32) {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -9,15 +9,15 @@ use embedded_hal_zero::blocking::delay::{DelayMs as DelayMsZero, DelayUs as Dela
 /// bit-banging protocols, etc
 #[derive(Copy, Clone)]
 pub struct McycleDelay {
+    /// System clock frequency, used to convert clock cycles
+    /// into real-world time values
     core_frequency: u32,
 }
 
 impl McycleDelay {
     /// Constructs the delay provider based on core clock frequency `freq`
     pub fn new(freq: u32) -> Self {
-        Self {
-            /// System clock frequency, used to convert clock cycles
-            /// into real-world time values
+        Self {        
             core_frequency: freq,
         }
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -459,11 +459,11 @@ macro_rules! impl_glb {
             }
 
             impl<MODE> InputPin for $Pini<Input<MODE>> {
-                fn is_high(&self) -> Result<bool, Self::Error> {
+                fn is_high(&mut self) -> Result<bool, Self::Error> {
                     Ok(self.is_high_inner())
                 }
 
-                fn is_low(&self) -> Result<bool, Self::Error> {
+                fn is_low(&mut self) -> Result<bool, Self::Error> {
                     Ok(self.is_low_inner())
                 }
             }
@@ -570,11 +570,11 @@ macro_rules! impl_glb {
             }
 
             impl<MODE> StatefulOutputPin for $Pini<Output<MODE>> {
-                fn is_set_high(&self) -> Result<bool, Self::Error> {
+                fn is_set_high(&mut self) -> Result<bool, Self::Error> {
                     Ok(self.is_output_high_inner())
                 }
 
-                fn is_set_low(&self) -> Result<bool, Self::Error> {
+                fn is_set_low(&mut self) -> Result<bool, Self::Error> {
                     Ok(self.is_output_low_inner())
                 }
             }


### PR DESCRIPTION
Just a few changes between rc1 and rc3.
DelayUs is replaced with DelayNs (which has default impls for DelayMs and DelayUs but I've kept the original implementations.
GPIO pin functions now take &mut instead of & to ensure that only one borrower can be active at a time.