### PR TITLE
Fix i2c write

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -41,6 +41,11 @@ impl McycleDelay {
 
         while McycleDelay::cycles_since(start_cycle_count) <= cycle_count {}
     }
+
+    pub fn ms_since(&mut self, previous_cycle_count: u64) -> u64 {
+        let elapsed_cycles = Self::cycles_since(previous_cycle_count);
+        (elapsed_cycles * 1000) / self.core_frequency as u64
+    }
 }
 
 // embedded-hal 1.0 traits

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -46,6 +46,11 @@ impl McycleDelay {
         let elapsed_cycles = Self::cycles_since(previous_cycle_count);
         (elapsed_cycles * 1000) / self.core_frequency as u64
     }
+
+    pub fn us_since(&mut self, previous_cycle_count: u64) -> u64 {
+        let elapsed_cycles = Self::cycles_since(previous_cycle_count);
+        (elapsed_cycles * 1_000_000) / self.core_frequency as u64
+    }
 }
 
 // embedded-hal 1.0 traits

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -103,7 +103,7 @@ pub struct I2c<I2C, PINS> {
     i2c: I2C,
     /// sda and scl pins for this i2c interface
     pins: PINS,
-    /// timeout (in milliseconds)
+    /// timeout (in microseconds)
     timeout: u16,
 }
 
@@ -178,8 +178,8 @@ where
         (self.i2c, self.pins)
     }
 
-    /// Set the timeout (in milliseconds) when waiting for fifo (rx and tx).
-    /// This defaults to 2048
+    /// Set the timeout (in microseconds) when waiting for fifo (rx and tx).
+    /// This defaults to 2000us (2 milliseconds)
     pub fn set_timeout(&mut self, timeout: u16) {
         self.timeout = timeout;
     }
@@ -246,7 +246,7 @@ where
         for value in tmp.iter_mut() {
             let start_time = McycleDelay::get_cycle_count();
             while self.i2c.i2c_fifo_config_1.read().rx_fifo_cnt().bits() == 0 {
-                if delay.ms_since(start_time) > self.timeout.into() {
+                if delay.us_since(start_time) > self.timeout.into() {
                     return Err(Error::Timeout);
                 }
             }
@@ -315,7 +315,7 @@ where
         for value in tmp.iter() {
             let start_time = McycleDelay::get_cycle_count();
             while self.i2c.i2c_fifo_config_1.read().tx_fifo_cnt().bits() == 0 {
-                if delay.ms_since(start_time) > self.timeout.into() {
+                if delay.us_since(start_time) > self.timeout.into() {
                     return Err(Error::Timeout);
                 }
             }
@@ -327,7 +327,7 @@ where
         let start_time = McycleDelay::get_cycle_count();
         while self.i2c.i2c_fifo_config_1.read().tx_fifo_cnt().bits() < 2 {
             // wait for write fifo to be empty
-            if delay.ms_since(start_time) > self.timeout.into() {
+            if delay.us_since(start_time) > self.timeout.into() {
                 return Err(Error::Timeout);
             }
         }
@@ -335,7 +335,7 @@ where
         let start_time = McycleDelay::get_cycle_count();
         while self.i2c.i2c_bus_busy.read().sts_i2c_bus_busy().bit_is_set() {
             // wait for transfer to finish
-            if delay.ms_since(start_time) > self.timeout.into() {
+            if delay.us_since(start_time) > self.timeout.into() {
                 return Err(Error::Timeout);
             }
         }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -323,6 +323,14 @@ where
         }
 
         let start_time = McycleDelay::get_cycle_count();
+        while self.i2c.i2c_fifo_config_1.read().tx_fifo_cnt().bits() < 2 {
+            // wait for write fifo to be empty
+            if delay.ms_since(start_time) > self.timeout.into() {
+                return Err(Error::Timeout);
+            }
+        }
+
+        let start_time = McycleDelay::get_cycle_count();
         while self.i2c.i2c_bus_busy.read().sts_i2c_bus_busy().bit_is_set() {
             // wait for transfer to finish
             if delay.ms_since(start_time) > self.timeout.into() {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -99,8 +99,11 @@ where
 
 /// I2C peripheral operating in master mode supporting seven bit addressing
 pub struct I2c<I2C, PINS> {
+    /// i2c peripheral instance
     i2c: I2C,
+    /// sda and scl pins for this i2c interface
     pins: PINS,
+    /// timeout (in milliseconds)
     timeout: u16,
 }
 
@@ -175,8 +178,7 @@ where
         (self.i2c, self.pins)
     }
 
-    /// Set the timeout when waiting for fifo (rx and tx).
-    /// It's not a time unit but the number of cycles to wait.
+    /// Set the timeout (in milliseconds) when waiting for fifo (rx and tx).
     /// This defaults to 2048
     pub fn set_timeout(&mut self, timeout: u16) {
         self.timeout = timeout;


### PR DESCRIPTION
I2C write was unreliable for a few reasons.
1) timeouts were very short
2) we were only waiting for i2c_bus_busy to be cleared, which sometimes happens before the fifo is empty.

By switching timeouts to use elapsed microseconds (estimated via McycleDelay) and waiting for an empty fifo, I can reliably use a SSD1306 screen now. This was impossible before.

Resolves #48